### PR TITLE
Fixed importing type_name_units_enum name

### DIFF
--- a/GUI/resources/docGenerator/linearHTMLStyles/servdef_jsidl_db_cals.xsl
+++ b/GUI/resources/docGenerator/linearHTMLStyles/servdef_jsidl_db_cals.xsl
@@ -1145,7 +1145,11 @@
   
   <!-- used by variable_fields via type_and_units_field.  1 or more of them may exist -->
   <xsl:template match="jaus:type_and_units_enum" mode="cell">
-    <xsl:text>Index = </xsl:text><xsl:value-of select="@index"/><xsl:processing-instruction name="linebreak"/>
+    <xsl:text>Index = </xsl:text><xsl:value-of select="@index"/>
+    <xsl:if test="@name">
+        <xsl:text>: </xsl:text><xsl:value-of select="@name"/>
+    </xsl:if>
+    <xsl:processing-instruction name="linebreak"/>
     <xsl:if test="@field_type">
         <xsl:text>Field Type = </xsl:text><xsl:value-of select="@field_type"/>
       <xsl:processing-instruction name="linebreak"/>
@@ -1448,6 +1452,9 @@
      <xsl:value-of select="jaus:bit_range/@from_index"/>
      <xsl:text>..</xsl:text>
      <xsl:value-of select="jaus:bit_range/@to_index"/>
+     <xsl:if test="@name">
+        <xsl:text>: </xsl:text><xsl:value-of select="@name"/>
+    </xsl:if>
      <xsl:text>, </xsl:text>
     <xsl:processing-instruction name="linebreak"/>
     <xsl:apply-templates select="jaus:value_set" mode="cell"/>

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/TypeAndUnitsEnum.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/TypeAndUnitsEnum.java
@@ -49,7 +49,12 @@ public class TypeAndUnitsEnum
 		
 		com.u2d.generated.TypeAndUnitsEnum jmTypeAndUnitsEnum = new com.u2d.generated.TypeAndUnitsEnum();
 		
-		jmTypeAndUnitsEnum.getName().setValue("MUST_RENAME");
+                String name = jxTypeAndUnitsEnum.getName();
+                if(name == null || name.isEmpty()) {
+			jmTypeAndUnitsEnum.getName().setValue("MUST_RENAME");
+                } else {
+                	jmTypeAndUnitsEnum.getName().setValue(name);
+                }
 		
 		// Index
 		jmTypeAndUnitsEnum.getIndex().setValue(jxTypeAndUnitsEnum.getIndex());


### PR DESCRIPTION
Fixed importing type_name_units_enum name. The name attribute
was added in JSIDL 1.1, but JTS was always setting the name
to "MUST_RENAME".

Updated the code to set the name if it is available. Also update
the document generation to use the name field if available.

Fixed #15.