### PR TITLE
Fixed reaching end of RunJuniorRTE without returning value

### DIFF
--- a/GUI/templates/Common/src/Transport/JuniorRTE.cpp
+++ b/GUI/templates/Common/src/Transport/JuniorRTE.cpp
@@ -362,4 +362,5 @@ int DllExport RunJuniorRTE(std::string config_file)
     JrInfo << "Shutting down Junior RTE...\n";
     for (_iter = _transports.begin(); _iter != _transports.end(); ++_iter)
         delete (*_iter);
+    return 0;
 }


### PR DESCRIPTION
Fixed reaching end of RunJuniorRTE without returning value.
This causes compiler warnings on some systems. Returning 0
by now.

Fixed #13.