### PR TITLE
Fixed memory leaks in NodeManager test code

### DIFF
--- a/nodeManager/test/CommsTestClient_251/urn_jts_comms_test_client_1_0/src/CommsTestClientFSM.cpp
+++ b/nodeManager/test/CommsTestClient_251/urn_jts_comms_test_client_1_0/src/CommsTestClientFSM.cpp
@@ -246,7 +246,7 @@ void CommsTestClientFSM::sendCommsTestMsgAction()
 	sendJausMessage(comms_msg, server);
 
 	// Free the allocated buffers
-	delete data;
+	delete[] data;
 
 	// Start the timer....
 	timer->start();

--- a/nodeManager/test/CommsTestClient_251/urn_jts_comms_test_client_1_0/src/Messages/ReportServices.cpp
+++ b/nodeManager/test/CommsTestClient_251/urn_jts_comms_test_client_1_0/src/Messages/ReportServices.cpp
@@ -625,7 +625,7 @@ void ReportServices::Body::NodeListResponse::NodeSeqResponse::ComponentListRespo
 	m_URITemp[length] = '\0';
 	m_URI = m_URITemp;
 	pos += length ;
-	delete m_URITemp;
+	delete[] m_URITemp;
 	jUnsignedByte m_MajorVersionNumberTemp;
 	
 	memcpy(&m_MajorVersionNumberTemp, bytes + pos, sizeof(jUnsignedByte));

--- a/nodeManager/test/CommsTestServer_250/urn_jts_comms_test_server_1_0/src/Messages/ReportServices.cpp
+++ b/nodeManager/test/CommsTestServer_250/urn_jts_comms_test_server_1_0/src/Messages/ReportServices.cpp
@@ -625,7 +625,7 @@ void ReportServices::Body::NodeListResponse::NodeSeqResponse::ComponentListRespo
 	m_URITemp[length] = '\0';
 	m_URI = m_URITemp;
 	pos += length ;
-	delete m_URITemp;
+	delete[] m_URITemp;
 	jUnsignedByte m_MajorVersionNumberTemp;
 	
 	memcpy(&m_MajorVersionNumberTemp, bytes + pos, sizeof(jUnsignedByte));


### PR DESCRIPTION
Fixed memory leaks in NodeManager test code. The test code
was creating new arrays, but not calling delete[].

Fixed #18.