### PR TITLE
Fixed sorting bitfields by index

### DIFF
--- a/GUI/src/org/jts/gui/JAXBtoJmatter/BitField.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/BitField.java
@@ -33,8 +33,10 @@ POSSIBILITY OF SUCH DAMAGE.
 package org.jts.gui.JAXBtoJmatter;
 
 import org.jts.gui.importJSIDL.ImportMessages;
+import org.jts.gui.util.SubFieldComparator;
 
 import com.u2d.app.Context;
+import java.util.Collections;
 
 import java.util.List;
 
@@ -94,6 +96,9 @@ public class BitField
 		    List jxList = jxBitField.getSubField();
 		    if(jxList != null)
 		    {
+        	        // Sort the SubFields first by BitRange, then by name.
+	                Collections.sort(jxList, new SubFieldComparator());
+
 		    	List jmList = jmBitField.getSubFields().getItems();
 		    	for(int i = 0; i < jxList.size(); i++)
 		    	{

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java
@@ -33,8 +33,11 @@ package org.jts.gui.importJSIDL.declaredElementsResolution;
 
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
+import org.jts.gui.util.SubFieldComparator;
 
 public class DeclaredTypeMap {
 
@@ -405,6 +408,9 @@ public class DeclaredTypeMap {
             element_copy.setFieldTypeUnsigned(element.getFieldTypeUnsigned());
             java.util.List<org.jts.jsidl.binding.SubField> list = element.getSubField();
             if (list != null) {
+                // Sort the SubFields first by BitRange, then by name.
+                Collections.sort(list, new SubFieldComparator());
+
                 java.util.List<org.jts.jsidl.binding.SubField> list_copy = element_copy.getSubField();
                 for (int ii = 0; ii < list.size(); ii++) {
                     list_copy.add(list.get(ii));

--- a/GUI/src/org/jts/gui/jmatterToJAXB/BitField.java
+++ b/GUI/src/org/jts/gui/jmatterToJAXB/BitField.java
@@ -32,9 +32,11 @@ POSSIBILITY OF SUCH DAMAGE.
 
 package org.jts.gui.jmatterToJAXB;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.jts.gui.util.Conversion;
+import org.jts.gui.util.SubFieldComparator;
 
 /* Converts JMatter BitField to a JAXB BitField.
 */
@@ -63,6 +65,7 @@ public class BitField {
      {
     	 jxList.add(org.jts.gui.jmatterToJAXB.SubField.convert((com.u2d.generated.SubField)jmList.get(ii)));
      }
+     Collections.sort(jxList, new SubFieldComparator());
       
      return bf;
   }

--- a/GUI/src/org/jts/gui/util/SubFieldComparator.java
+++ b/GUI/src/org/jts/gui/util/SubFieldComparator.java
@@ -1,0 +1,59 @@
+package org.jts.gui.util;
+
+import java.util.Comparator;
+
+/**
+ * Compares SubFields first by BitRange, then by name. This class is useful
+ * for sorting SubFields in a collection.
+ * 
+ * @author cgagner
+ */
+public class SubFieldComparator implements Comparator<org.jts.jsidl.binding.SubField> {
+
+    /**
+     * Compare the names of two SubFields
+     */
+    private int compareNames(String name1, String name2) {
+        if (name1 == null && name2 == null) {
+            return 0;
+        } else if (name1 == null) {
+            return -1;
+        } else if (name2 == null) {
+            return 1;
+        } else {
+            return name1.compareTo(name2);
+        }
+    }
+
+    /**
+     * Compares two SubFields first by BitRane, then by name.
+     * @param lhs SubField on the left-hand-side
+     * @param rhs SubField on the right-hand-side
+     * @return 1 if rhs should be before lhs; -1 if lhs should be before rhs; 
+     * 0 otherwise.
+     */
+    public int compare(org.jts.jsidl.binding.SubField lhs, org.jts.jsidl.binding.SubField rhs) {
+
+        String name1 = lhs.getName();
+        String name2 = rhs.getName();
+        org.jts.jsidl.binding.BitRange range1 = lhs.getBitRange();
+        org.jts.jsidl.binding.BitRange range2 = rhs.getBitRange();
+        if (range1 == null || range2 == null) {
+            return compareNames(name1, name2);
+        } else {
+            if (range1.getFromIndex() < range2.getFromIndex()) {
+                return -1;
+            } else if (range1.getFromIndex() > range2.getFromIndex()) {
+                return 1;
+            } else {
+                if (range1.getToIndex() < range2.getToIndex()) {
+                    return -1;
+                } else if (range1.getToIndex() > range2.getToIndex()) {
+                    return 1;
+                } else {
+                    return compareNames(name1, name2);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixed sorting bitfields by index.
  * gui/JAXBtoJmatter/BitField.java:
    - Updated the lookupOrCreate() method to sort bitfields
      by index.
  * gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java:
    - Updated the lookupDeclaredBitField() method to sort
      bitfields by index.
  * gui/jmatterToJAXB/BitField.java:
    - Updated the convert() method to sort bitfields by index.
  * gui/util/SubFieldComparator.java
    - Created comparator for sorting bitfields by index.

Fixed #20.