### PR TITLE
Fixed setting names to MUST_RENAME when importing JSIDL

### DIFF
--- a/GUI/resources/schema/JSIDL_Plus/jsidl_plus.rnc
+++ b/GUI/resources/schema/JSIDL_Plus/jsidl_plus.rnc
@@ -558,8 +558,10 @@ format_enum =
        attribute_field_format
    }
 
+# Name attribute added in REV_A of JSIDL 1.0
 value_set = 
    element value_set {
+      attribute name { identifier }?,
       attribute offset_to_lower_limit { xsd:boolean },
       (value_range | value_enum)+
    }

--- a/GUI/resources/schema/JSIDL_Plus/jsidl_plus.xsd
+++ b/GUI/resources/schema/JSIDL_Plus/jsidl_plus.xsd
@@ -807,12 +807,14 @@
       <xs:attributeGroup ref="ns1:attribute_field_format"/>
     </xs:complexType>
   </xs:element>
+  <!-- Name attribute added in REV_A of JSIDL 1.0 -->
   <xs:element name="value_set">
     <xs:complexType>
       <xs:choice maxOccurs="unbounded">
         <xs:element ref="ns1:value_range"/>
         <xs:element ref="ns1:value_enum"/>
       </xs:choice>
+      <xs:attribute name="name" type="ns1:identifier"/>
       <xs:attribute name="offset_to_lower_limit" use="required" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/FormatEnum.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/FormatEnum.java
@@ -46,7 +46,12 @@ public class FormatEnum
 		// NOTE: There is nothing significant in a FormatEnum's definition that would allow it to be looked up in the db
 		com.u2d.generated.FormatEnum jmFormatEnum = new com.u2d.generated.FormatEnum();
 		
-		jmFormatEnum.getName().setValue("MUST_RENAME");
+                String name = jxFormatEnum.getFieldFormat();
+                if(name == null || name.isEmpty()) {
+                    jmFormatEnum.getName().setValue("MUST_RENAME");
+                } else {
+                    jmFormatEnum.getName().setValue(name);
+                }
 		
 		// Index
 		jmFormatEnum.getIndex().setValue(jxFormatEnum.getIndex());

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/TypeAndUnitsEnum.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/TypeAndUnitsEnum.java
@@ -49,7 +49,12 @@ public class TypeAndUnitsEnum
 		
 		com.u2d.generated.TypeAndUnitsEnum jmTypeAndUnitsEnum = new com.u2d.generated.TypeAndUnitsEnum();
 		
-		jmTypeAndUnitsEnum.getName().setValue("MUST_RENAME");
+                String name = jxTypeAndUnitsEnum.getName();
+                if(name == null || name.isEmpty()) {
+		  jmTypeAndUnitsEnum.getName().setValue("MUST_RENAME");
+                } else {
+                  jmTypeAndUnitsEnum.getName().setValue(name);
+                }
 		
 		// Index
 		jmTypeAndUnitsEnum.getIndex().setValue(jxTypeAndUnitsEnum.getIndex());

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/ValueEnum.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/ValueEnum.java
@@ -65,7 +65,12 @@ public class ValueEnum
 			jmValueEnum = new com.u2d.generated.ValueEnum();
 			
 			// set name
-		      jmValueEnum.getName().setValue("MUST_RENAME");
+                      String name = jxValueEnum.getEnumConst();
+                      if(name == null || name.isEmpty()) {
+                          jmValueEnum.getName().setValue("MUST_RENAME");
+                      } else {
+                          jmValueEnum.getName().setValue(name);
+                      }
 			
 			// Interpretation
 		    if(jxValueEnum.getInterpretation() != null)

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/ValueSet.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/ValueSet.java
@@ -51,7 +51,12 @@ public class ValueSet
 		com.u2d.generated.ValueSet jmValueSet = new com.u2d.generated.ValueSet();
 		
 		// set name
-		jmValueSet.getName().setValue("MUST_RENAME");
+                String name = jxValueSet.getName();
+                if(name == null || name.isEmpty()) {
+                    jmValueSet.getName().setValue("MUST_RENAME");
+                } else {
+                    jmValueSet.getName().setValue(name);
+                }
 		
 		// Offset To Lower Limit
 		jmValueSet.getOffsetToLowerLimit().setValue(jxValueSet.isOffsetToLowerLimit());


### PR DESCRIPTION
Fixed setting names to MUST_RENAME when importing JSIDL.
  * gui/JAXBtoJmatter/FormatEnum.java:
    - Set the name to the ```format_field```.
  * gui/JAXBtoJmatter/TypeAndUnitsEnum.java:
    - Set the name to ```name```.
  * gui/JAXBtoJmatter/ValueEnum.java:
    - Set the name to ```enum_const```.
  * gui/JAXBtoJmatter/ValueSet.java:
    - Set the name to ```name```.

Fixed #24.