### PR TITLE
Updated JSerial to allow flow control to be disabled

### DIFF
--- a/nodeManager/src/nm.cfg
+++ b/nodeManager/src/nm.cfg
@@ -189,6 +189,15 @@
         #        but is much less efficient.  The following configuration item should
         #        only be enabled if hardware flow control is not supported on the 
         #        communication port.
+        #
+        # SerialFlowControlEnabled:  A serial port may use signals in the interface
+        #        to pause and resume the transmission of data. For example, a 
+        #        slow printer might need to handshake with the serial port to 
+        #        indicate that data should be paused while the mechanism advances a 
+        #        line. These signals can implemented by hardware or by software.
+        #        Use 1 to enabled flow control. Use 0 to disbale flow control.
+        #        If flow control is enabled, use SerialSoftwareFlowControl to
+        #        configure hardware or software. Flow control is enabled by default.
     -->
     <Serial_Configuration
         SerialPortName = "com1"  
@@ -196,6 +205,7 @@
         SerialParity = "none"
         SerialStopBits = "1"
         SerialSoftwareFlowControl = "0"
+        SerialFlowControlEnabled = "1"
     />
   
     <!--


### PR DESCRIPTION
Updated JSerial to allow flow control to be disabled. Add the
SerialFlowControlEnabled:

A serial port may use signals in the interface
to pause and resume the transmission of data. For example, a
slow printer might need to handshake with the serial port to
indicate that data should be paused while the mechanism advances a
line. These signals can implemented by hardware or by software.
Use 1 to enabled flow control. Use 0 to disbale flow control.
If flow control is enabled, use SerialSoftwareFlowControl to
configure hardware or software. Flow control is enabled by default.

Fixed #27.