### PR TITLE
Fixed interpretation attributes truncated to 255 chars

### DIFF
--- a/GUI/src/com/u2d/generated/BitField.java
+++ b/GUI/src/com/u2d/generated/BitField.java
@@ -47,8 +47,8 @@ public  class BitField extends SimpleField {
     public PrimitiveTypeUnsigned getType() { return type;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/BitRange.java
+++ b/GUI/src/com/u2d/generated/BitRange.java
@@ -43,8 +43,8 @@ public  class BitRange extends AbstractComplexEObject_JTS{
     public IntEO getToIndex() { return toIndex;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
  

--- a/GUI/src/com/u2d/generated/Body.java
+++ b/GUI/src/com/u2d/generated/Body.java
@@ -39,8 +39,8 @@ public  class Body extends AbstractComplexEObject_JTS{
     public StringEO getName() { return name;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/Component.java
+++ b/GUI/src/com/u2d/generated/Component.java
@@ -44,8 +44,8 @@ public  class Component extends AbstractComplexEObject_JTS{
     public IntEO getComponentId() { return componentId;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/Constant.java
+++ b/GUI/src/com/u2d/generated/Constant.java
@@ -51,8 +51,8 @@ public  class Constant extends AbstractComplexEObject_JTS{
     public StringEO getValue() { return value;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/Dimension.java
+++ b/GUI/src/com/u2d/generated/Dimension.java
@@ -43,8 +43,8 @@ public  class Dimension extends AbstractComplexEObject_JTS{
     public IntEO getSize() { return size;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/FixedField.java
+++ b/GUI/src/com/u2d/generated/FixedField.java
@@ -51,8 +51,8 @@ public  class FixedField extends SimpleField {
     public SIUnit getUnits() { return units;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
     // ******    scaleRange   ******
     private final ScaleRange scaleRange = new ScaleRange();

--- a/GUI/src/com/u2d/generated/FixedLengthString.java
+++ b/GUI/src/com/u2d/generated/FixedLengthString.java
@@ -47,8 +47,8 @@ public  class FixedLengthString extends SimpleField {
     public IntEO getStringLength() { return stringLength;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
  

--- a/GUI/src/com/u2d/generated/Footer.java
+++ b/GUI/src/com/u2d/generated/Footer.java
@@ -39,8 +39,8 @@ public  class Footer extends AbstractComplexEObject_JTS{
     public StringEO getName() { return name;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/Header.java
+++ b/GUI/src/com/u2d/generated/Header.java
@@ -39,8 +39,8 @@ public  class Header extends AbstractComplexEObject_JTS{
     public StringEO getName() { return name;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/List.java
+++ b/GUI/src/com/u2d/generated/List.java
@@ -51,8 +51,8 @@ public  class List extends ComplexField {
     public LongEO getMaxSize() { return maxSize;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/Record.java
+++ b/GUI/src/com/u2d/generated/Record.java
@@ -43,8 +43,8 @@ public  class Record extends ComplexField {
     public BooleanEO getOptional() { return optional;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/ScaleRange.java
+++ b/GUI/src/com/u2d/generated/ScaleRange.java
@@ -43,8 +43,8 @@ public  class ScaleRange extends AbstractComplexEObject_JTS{
     public StringEO getRealUpperLimit() { return realUpperLimit;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
  

--- a/GUI/src/com/u2d/generated/Sequence.java
+++ b/GUI/src/com/u2d/generated/Sequence.java
@@ -43,8 +43,8 @@ public  class Sequence extends ComplexField {
     public BooleanEO getOptional() { return optional;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/SubField.java
+++ b/GUI/src/com/u2d/generated/SubField.java
@@ -45,8 +45,8 @@ public  class SubField extends AbstractComplexEObject_JTS{
     public BitRange getBitRange() { return bitRange;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/ValueEnum.java
+++ b/GUI/src/com/u2d/generated/ValueEnum.java
@@ -47,8 +47,8 @@ public  class ValueEnum extends AbstractComplexEObject_JTS{
     public StringEO getEnumConstant() { return enumConstant;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/ValueRange.java
+++ b/GUI/src/com/u2d/generated/ValueRange.java
@@ -47,8 +47,8 @@ public  class ValueRange extends AbstractComplexEObject_JTS{
     public StringEO getUpperLimit() { return upperLimit;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/VariableField.java
+++ b/GUI/src/com/u2d/generated/VariableField.java
@@ -43,8 +43,8 @@ public  class VariableField extends SimpleField {
     public BooleanEO getOptional() { return optional;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/VariableFormatField.java
+++ b/GUI/src/com/u2d/generated/VariableFormatField.java
@@ -51,8 +51,8 @@ public  class VariableFormatField extends SimpleField {
     public LongEO getMaxSize() { return maxSize;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/com/u2d/generated/VariableLengthField.java
+++ b/GUI/src/com/u2d/generated/VariableLengthField.java
@@ -55,8 +55,8 @@ public  class VariableLengthField extends SimpleField {
     public LongEO getMaxSize() { return maxSize;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
  

--- a/GUI/src/com/u2d/generated/VariableLengthString.java
+++ b/GUI/src/com/u2d/generated/VariableLengthString.java
@@ -51,8 +51,8 @@ public  class VariableLengthString extends SimpleField {
     public LongEO getMaxLength() { return maxLength;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
  

--- a/GUI/src/com/u2d/generated/Variant.java
+++ b/GUI/src/com/u2d/generated/Variant.java
@@ -43,8 +43,8 @@ public  class Variant extends ComplexField {
     public BooleanEO getOptional() { return optional;}
 
     // ******    interpretation   ******
-    private final StringEO interpretation = new StringEO();
-    public StringEO getInterpretation() { return interpretation;}
+    private final TextEO interpretation = new TextEO();
+    public TextEO getInterpretation() { return interpretation;}
 
    
 

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/BitField.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/BitField.java
@@ -72,18 +72,18 @@ public class BitField
 		    if(jxBitField.getInterpretation() != null)
 		    {
 		    	String interpretation = jxBitField.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmBitField.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "BitField ("+jxBitField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmBitField.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "BitField ("+jxBitField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmBitField.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 
 		    // FieldTypeUnsigned

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/Constant.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/Constant.java
@@ -76,18 +76,18 @@ public class Constant
 			if(jxConstDef.getInterpretation() != null)
 			{
 		    	String interpretation = jxConstDef.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmConstDef.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "Constant ("+jmConstDef.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmConstDef.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "Constant ("+jmConstDef.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmConstDef.getInterpretation().setValue(interpretation);
-				}
+//				}
 			}
 			
 			// ConstType

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/Dimension.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/Dimension.java
@@ -75,18 +75,18 @@ public class Dimension
 		    if(jxDimension.getInterpretation() != null)
 		    {
 		    	String interpretation = jxDimension.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmDimension.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "Dimension ("+jxDimension.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmDimension.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "Dimension ("+jxDimension.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmDimension.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 
 			

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/FixedField.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/FixedField.java
@@ -74,19 +74,19 @@ public class FixedField
 		    // Interpretation
 		    if(jxFixedField.getInterpretation() != null)
 		    {
-		    	String interpretation = jxFixedField.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmFixedField.getInterpretation().setValue(temp);
-					
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "FixedField ("+jxFixedField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+		    	String interpretation = jxFixedField.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmFixedField.getInterpretation().setValue(temp);
+//					
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "FixedField ("+jxFixedField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmFixedField.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 		    
 		    jmFixedField.getType().getCode().setValue(jxFixedField.getFieldType());
@@ -111,18 +111,18 @@ public class FixedField
 			    if(jxScaleRange.getInterpretation() != null)
 			    {
 			    	String interpretation = jxScaleRange.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-					if(interpretation.length() > 255)
-					{
-						String temp = interpretation.substring(0, 255);
-						jmScaleRange.getInterpretation().setValue(temp);
-
-						ImportMessages importMsgs = ImportMessages.getInstance();
-						importMsgs.add(ImportMessages.MessageType.WARNING, "FixedField ("+jxFixedField.getName()+") scaleRange interpretaion attribute was truncated to: \"" + temp +"\"");
-					}
-					else
-					{
+//					if(interpretation.length() > 255)
+//					{
+//						String temp = interpretation.substring(0, 255);
+//						jmScaleRange.getInterpretation().setValue(temp);
+//
+//						ImportMessages importMsgs = ImportMessages.getInstance();
+//						importMsgs.add(ImportMessages.MessageType.WARNING, "FixedField ("+jxFixedField.getName()+") scaleRange interpretaion attribute was truncated to: \"" + temp +"\"");
+//					}
+//					else
+//					{
 						jmScaleRange.getInterpretation().setValue(interpretation);
-					}
+//					}
 			    }
 		    }
 		    

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/FixedLengthString.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/FixedLengthString.java
@@ -76,18 +76,18 @@ public class FixedLengthString
 		    if(jxFixedLengthString.getInterpretation() != null)
 		    {
 		    	String interpretation = jxFixedLengthString.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmFixedLengthString.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "FixedLengthString ("+jxFixedLengthString.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmFixedLengthString.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "FixedLengthString ("+jxFixedLengthString.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmFixedLengthString.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 
 		    // String Length

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/List.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/List.java
@@ -71,18 +71,18 @@ public class List
 		    if(jxList.getInterpretation() != null)
 		    {
 		    	String interpretation = jxList.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmList.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "List ("+jxList.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmList.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "List ("+jxList.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmList.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 			
 			// Optional

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/Record.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/Record.java
@@ -76,18 +76,18 @@ public class Record
 		    if(jxRecord.getInterpretation() != null)
 		    {
 		    	String interpretation = jxRecord.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmRecord.getInterpretation().setValue( temp );
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "Record ("+jxRecord.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmRecord.getInterpretation().setValue( temp );
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "Record ("+jxRecord.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmRecord.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 
 		    // Presence Vector (dropped)

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/Sequence.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/Sequence.java
@@ -75,18 +75,18 @@ public class Sequence
 		    if(jxSequence.getInterpretation() != null)
 		    {
 		    	String interpretation = jxSequence.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmSequence.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "Sequence ("+jxSequence.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmSequence.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "Sequence ("+jxSequence.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmSequence.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 			
 			// Optional

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/SubField.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/SubField.java
@@ -57,18 +57,18 @@ public class SubField
 	    if(jxSubField.getInterpretation() != null)
 	    {
 	    	String interpretation = jxSubField.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-			if(interpretation.length() > 255)
-			{
-				String temp = interpretation.substring(0, 255);
-				jmSubField.getInterpretation().setValue(temp);
-
-				ImportMessages importMsgs = ImportMessages.getInstance();
-				importMsgs.add(ImportMessages.MessageType.WARNING, "SubField ("+jxSubField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-			}
-			else
-			{
+//			if(interpretation.length() > 255)
+//			{
+//				String temp = interpretation.substring(0, 255);
+//				jmSubField.getInterpretation().setValue(temp);
+//
+//				ImportMessages importMsgs = ImportMessages.getInstance();
+//				importMsgs.add(ImportMessages.MessageType.WARNING, "SubField ("+jxSubField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//			}
+//			else
+//			{
 				jmSubField.getInterpretation().setValue(interpretation);
-			}
+//			}
 	    }
 
 	    // BitRange
@@ -85,18 +85,18 @@ public class SubField
 		if(jxBitRange.getInterpretation() != null)
 		{
 			String interpretation = jxBitRange.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-			if(interpretation.length() > 255)
-			{
-				String temp = interpretation.substring(0, 255);
-				jmBitRange.getInterpretation().setValue(temp);
-
-				ImportMessages importMsgs = ImportMessages.getInstance();
-				importMsgs.add(ImportMessages.MessageType.WARNING, "BitRange interpretation attribute was truncated to: \"" + temp +"\"");
-			}
-			else
-			{
+//			if(interpretation.length() > 255)
+//			{
+//				String temp = interpretation.substring(0, 255);
+//				jmBitRange.getInterpretation().setValue(temp);
+//
+//				ImportMessages importMsgs = ImportMessages.getInstance();
+//				importMsgs.add(ImportMessages.MessageType.WARNING, "BitRange interpretation attribute was truncated to: \"" + temp +"\"");
+//			}
+//			else
+//			{
 				jmBitRange.getInterpretation().setValue(interpretation);
-			}
+//			}
 		}
 		
 		// Value Set

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/TypeAndUnitsEnum.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/TypeAndUnitsEnum.java
@@ -78,18 +78,18 @@ public class TypeAndUnitsEnum
 		    if(jxScaleRange.getInterpretation() != null)
 		    {
 		    	String interpretation = jxScaleRange.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmScaleRange.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "ScaleRange interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmScaleRange.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "ScaleRange interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmScaleRange.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 	    }
 	    

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/ValueEnum.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/ValueEnum.java
@@ -71,18 +71,18 @@ public class ValueEnum
 		    if(jxValueEnum.getInterpretation() != null)
 		    {
 		    	String interpretation = jxValueEnum.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmValueEnum.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "ValueEnum interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmValueEnum.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "ValueEnum interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmValueEnum.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 			
 			// Enum Index

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/ValueRange.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/ValueRange.java
@@ -72,18 +72,18 @@ public class ValueRange
 		    if(jxValueRange.getInterpretation() != null)
 		    {
 		    	String interpretation = jxValueRange.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmValueRange.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "ValueRange interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmValueRange.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "ValueRange interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmValueRange.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 			
 			// Lower Limit

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/VariableField.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/VariableField.java
@@ -73,18 +73,18 @@ public class VariableField
 		    if(jxVariableField.getInterpretation() != null)
 		    {
 		    	String interpretation = jxVariableField.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmVariableField.getInterpretation().setValue( temp );
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "VariableField ("+jxVariableField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmVariableField.getInterpretation().setValue( temp );
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "VariableField ("+jxVariableField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmVariableField.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 
 		    java.util.List jxList = jxVariableField.getTypeAndUnitsField().getTypeAndUnitsEnum();

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/VariableFormatField.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/VariableFormatField.java
@@ -74,18 +74,18 @@ public class VariableFormatField
 		    if(jxVariableFormatField.getInterpretation() != null)
 		    {
 		    	String interpretation = jxVariableFormatField.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmVariableFormatField.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "VariableFormatField ("+jxVariableFormatField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmVariableFormatField.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "VariableFormatField ("+jxVariableFormatField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmVariableFormatField.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 
 		    java.util.List jxList = jxVariableFormatField.getFormatField().getFormatEnum();

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/VariableLengthField.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/VariableLengthField.java
@@ -74,18 +74,18 @@ public class VariableLengthField
 			if(jxVariableLengthField.getInterpretation() != null)
 			{
 				String interpretation = jxVariableLengthField.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmVariableLengthField.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "VariableLengthField ("+jxVariableLengthField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmVariableLengthField.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "VariableLengthField ("+jxVariableLengthField.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmVariableLengthField.getInterpretation().setValue(interpretation);
-				}
+//				}
 			}
 
 		    // Count Field.  Since it's been 'fixed' earlier, we don't need to handle

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/VariableLengthString.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/VariableLengthString.java
@@ -74,18 +74,18 @@ public class VariableLengthString
 		    if(jxVariableLengthString.getInterpretation() != null)
 		    {
 		    	String interpretation = jxVariableLengthString.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmVariableLengthString.getInterpretation().setValue(temp);
-					
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "VariableLengthString ("+jxVariableLengthString.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmVariableLengthString.getInterpretation().setValue(temp);
+//					
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "VariableLengthString ("+jxVariableLengthString.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmVariableLengthString.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 
 		    // Count Field.  Since it's been 'fixed' earlier, we don't need to handle

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/Variant.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/Variant.java
@@ -73,18 +73,18 @@ public class Variant
 		    if(jxVariant.getInterpretation() != null)
 		    {
 		    	String interpretation = jxVariant.getInterpretation().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
-				if(interpretation.length() > 255)
-				{
-					String temp = interpretation.substring(0, 255);
-					jmVariant.getInterpretation().setValue(temp);
-
-					ImportMessages importMsgs = ImportMessages.getInstance();
-					importMsgs.add(ImportMessages.MessageType.WARNING, "Variant ("+jxVariant.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
-				}
-				else
-				{
+//				if(interpretation.length() > 255)
+//				{
+//					String temp = interpretation.substring(0, 255);
+//					jmVariant.getInterpretation().setValue(temp);
+//
+//					ImportMessages importMsgs = ImportMessages.getInstance();
+//					importMsgs.add(ImportMessages.MessageType.WARNING, "Variant ("+jxVariant.getName()+") interpretation attribute was truncated to: \"" + temp +"\"");
+//				}
+//				else
+//				{
 					jmVariant.getInterpretation().setValue(interpretation);
-				}
+//				}
 		    }
 			
 			// Optional

--- a/GUI/src/org/jts/gui/util/Conversion.java
+++ b/GUI/src/org/jts/gui/util/Conversion.java
@@ -12,6 +12,7 @@ import com.u2d.app.Context;
 import com.u2d.generated.Array;
 import com.u2d.type.atom.BooleanEO;
 import com.u2d.type.atom.StringEO;
+import com.u2d.type.atom.TextEO;
 
 public class Conversion
 {
@@ -33,11 +34,24 @@ public class Conversion
 			Method getInterpretation = inputClass.getMethod("getInterpretation");
 			Method setInterpretation = outputClass.getMethod("setInterpretation", String.class);
 			
-			StringEO interpretationEO = (StringEO)getInterpretation.invoke( input );
-			Method toString = StringEO.class.getMethod("toString");
-			
-			String interpretation = (String)toString.invoke(interpretationEO);
-			
+                        String interpretation = "";
+                        if (getInterpretation.getReturnType().equals(StringEO.class)) {
+                            StringEO interpretationEO = (StringEO) getInterpretation.invoke(input);
+                            if (interpretationEO != null) {
+                                interpretation = interpretationEO.toString();
+                            }
+                        } else if (getInterpretation.getReturnType().equals(TextEO.class)) {
+                            TextEO interpretationEO = (TextEO) getInterpretation.invoke(input);
+                            if (interpretationEO != null) {
+                                interpretation = interpretationEO.toString();
+                            }
+                        } else if (getInterpretation.getReturnType().equals(String.class)) {
+                            String interpretationEO = (String) getInterpretation.invoke(input);
+                            if(interpretationEO != null) {
+                                interpretation = interpretationEO;
+                            }
+                        }
+                        
 			if( !interpretation.isEmpty() )
 			{
 				setInterpretation.invoke( output, interpretation );


### PR DESCRIPTION
Fixed interpretation attributes being truncated to 255 characters.
Needed to update the ```GUI/src/com/u2d/generated/``` classes to switch
the interpretation from a ```StringEO``` to a ```TextEO```. Also needed
to update the ```GUI/src/org/jts/gui/JAXBtoJmatter/``` classes to
stop truncating the string if it is more than 255 characters.

Finally, needed to update ```GUI/src/org/jts/gui/util/Conversion.java```
because the ```setNonEmptyDescription``` method uses reflection to
get the interpretation. It was casting it to a ```StringEO```. I've
update the method to handle ```StringEO```, ```TextEO```, and ```String```.

Fixed #12.