### PR TITLE
Updates to support JSIDL 1.1

### DIFF
--- a/GUI/resources/schema/JSIDL/jsidl.rnc
+++ b/GUI/resources/schema/JSIDL/jsidl.rnc
@@ -1,6 +1,7 @@
 # JAUS Service Interface Definition Language (JSIDLv1.1)
 #
 default namespace = "urn:jaus:jsidl:1.1"
+datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
 
 start = service_def | declared_type_set | declared_const_set
 
@@ -37,19 +38,19 @@ references =
   
 inherits_from = 
   element inherits_from {
-    attribute name { identifier },
-  attribute id { xsd:anyURI },
-  attribute version { version_num_ref },
-  attribute interpretation { text }?
+    ref_attr
   }
   
 client_of = 
   element client_of {
-    attribute name { identifier },
-  attribute id { xsd:anyURI },
-  attribute version { version_num_ref },
-  attribute interpretation { text }?
+    ref_attr
   }
+
+ref_attr =
+    attribute name { identifier },
+    attribute id { xsd:anyURI },
+    attribute version { version_num_ref },
+    attribute interpretation { text }?
 
   
   #==================== declared constants ===========================

--- a/GUI/resources/schema/JSIDL_Plus/jsidl_plus.rnc
+++ b/GUI/resources/schema/JSIDL_Plus/jsidl_plus.rnc
@@ -7,6 +7,7 @@ datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
 # additions are the following:
 # 1. service_set element
 # 2. Added mxCell element and sub-elements
+# 3. Updated variable_field to define type_and_units_field inline because defining it separately causes problems in the XSD. 
 
 namespace plus = "urn:jaus:jsidl:plus"
 
@@ -395,7 +396,9 @@ variable_field =
         attribute name { identifier }, 
         attribute optional {xsd:boolean },
         attribute interpretation { text }?,  
-        type_and_units_field
+        element type_and_units_field {
+          type_and_units_enum+
+        }
     }
     
 bit_field =
@@ -461,11 +464,6 @@ sub_field =
    element sub_field {
       attribute name { identifier }, bit_range, (value_set | declared_value_set),
       attribute interpretation { text }?
-   }   
-
-type_and_units_field = 
-    element type_and_units_field {
-      type_and_units_enum+ 
     }
     
 format_field = 

--- a/GUI/resources/schema/JSIDL_Plus/jsidl_plus.rnc
+++ b/GUI/resources/schema/JSIDL_Plus/jsidl_plus.rnc
@@ -1,13 +1,12 @@
 # JAUS Service Interface Definition Language (JSIDLv1.1)
 #
 default namespace = "urn:jaus:jsidl:1.1"
-
+datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
 
 # JSIDL+ only adds to JSIDL and does not modify or remove anything that already exists in JSIDL
 # additions are the following:
 # 1. service_set element
-# 2. Relaxes the requirement for optional flag on declared_variant, to permit import of JSIDL 1.0
-# 4. Added mxCell element and sub-elements
+# 2. Added mxCell element and sub-elements
 
 namespace plus = "urn:jaus:jsidl:plus"
 
@@ -57,19 +56,19 @@ references =
   
 inherits_from = 
   element inherits_from {
-    attribute name { identifier },
-  attribute id { xsd:anyURI },
-  attribute version { version_num_ref },
-  attribute interpretation { text }?
+    ref_attr
   }
   
 client_of = 
   element client_of {
-    attribute name { identifier },
-  attribute id { xsd:anyURI },
-  attribute version { version_num_ref },
-  attribute interpretation { text }?
+    ref_attr
   }
+
+ref_attr =
+    attribute name { identifier },
+    attribute id { xsd:anyURI },
+    attribute version { version_num_ref },
+    attribute interpretation { text }?
 
   
   #==================== declared constants ===========================
@@ -161,7 +160,7 @@ declared_footer =
 declared_variant =
    element declared_variant {
       attribute_declared_type,
-      attribute optional { xsd:boolean }?
+      attribute optional { xsd:boolean }
    }
 
 declared_sequence = 
@@ -619,7 +618,7 @@ state_machine =
    element state_machine {
      attribute name { identifier_ns },
      attribute interpretation { text }?,
-     state*, 
+     state+, 
      default_state?,
      pseudo_start_state?,
      mxCell?
@@ -810,7 +809,7 @@ identifier |= xsd:string { pattern="[a-zA-Z_][a-zA-Z_0-9]*" }
  
 identifier_ns |= xsd:string { pattern="[a-zA-Z_][a-zA-Z_0-9.]*" }
 
-# param type 
+# parameter type
  
 param_type |= "unsigned byte" 
                           | "unsigned short" 

--- a/GUI/resources/schema/JSIDL_Plus/jsidl_plus.xsd
+++ b/GUI/resources/schema/JSIDL_Plus/jsidl_plus.xsd
@@ -8,6 +8,7 @@
   additions are the following:
   1. service_set element
   2. Added mxCell element and sub-elements
+  3. Updated variable_field to define type_and_units_field inline because defining it separately causes problems in the XSD. 
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:jaus:jsidl:1.1" xmlns:ns1="urn:jaus:jsidl:1.1" xmlns:plus="urn:jaus:jsidl:plus">
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
@@ -542,13 +543,19 @@
   </xs:element>
   <xs:element name="variable_field">
     <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="ns1:type_and_units_field">
-          <xs:attribute name="name" use="required" type="ns1:identifier"/>
-          <xs:attribute name="optional" use="required" type="xs:boolean"/>
-          <xs:attribute name="interpretation"/>
-        </xs:extension>
-      </xs:complexContent>
+      <xs:sequence>
+        <xs:element ref="ns1:type_and_units_field"/>
+      </xs:sequence>
+      <xs:attribute name="name" use="required" type="ns1:identifier"/>
+      <xs:attribute name="optional" use="required" type="xs:boolean"/>
+      <xs:attribute name="interpretation"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="type_and_units_field">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="ns1:type_and_units_enum"/>
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="bit_field">
@@ -649,18 +656,6 @@
       </xs:sequence>
       <xs:attribute name="name" use="required" type="ns1:identifier"/>
       <xs:attribute name="interpretation"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:complexType name="type_and_units_field">
-    <xs:sequence>
-      <xs:element ref="ns1:type_and_units_field"/>
-    </xs:sequence>
-  </xs:complexType>
-  <xs:element name="type_and_units_field">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="ns1:type_and_units_enum"/>
-      </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="format_field">

--- a/GUI/resources/schema/JSIDL_Plus/jsidl_plus.xsd
+++ b/GUI/resources/schema/JSIDL_Plus/jsidl_plus.xsd
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  JAUS Service Interface Definition Language - Plus (JSIDL+v1.1)
+  JAUS Service Interface Definition Language (JSIDLv1.1)
   
 -->
 <!--
   JSIDL+ only adds to JSIDL and does not modify or remove anything that already exists in JSIDL
   additions are the following:
   1. service_set element
-  2. Relaxes the requirement for optional flag on declared_variant, to permit import of JSIDL 1.0
-  4. Added mxCell element and sub-elements  
+  2. Added mxCell element and sub-elements
 -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:jaus:jsidl:1.1" xmlns:plus="urn:jaus:jsidl:plus" xmlns:ns1="urn:jaus:jsidl:1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:jaus:jsidl:1.1" xmlns:ns1="urn:jaus:jsidl:1.1" xmlns:plus="urn:jaus:jsidl:plus">
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
   <xs:import namespace="urn:jaus:jsidl:plus" schemaLocation="plus.xsd"/>
   <xs:element name="service_def">
@@ -51,20 +50,20 @@
   </xs:element>
   <xs:element name="inherits_from">
     <xs:complexType>
-      <xs:attribute name="name" use="required" type="ns1:identifier"/>
-      <xs:attribute name="id" use="required" type="xs:anyURI"/>
-      <xs:attribute name="version" use="required" type="ns1:version_num_ref"/>
-      <xs:attribute name="interpretation"/>
+      <xs:attributeGroup ref="ns1:ref_attr"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="client_of">
     <xs:complexType>
-      <xs:attribute name="name" use="required" type="ns1:identifier"/>
-      <xs:attribute name="id" use="required" type="xs:anyURI"/>
-      <xs:attribute name="version" use="required" type="ns1:version_num_ref"/>
-      <xs:attribute name="interpretation"/>
+      <xs:attributeGroup ref="ns1:ref_attr"/>
     </xs:complexType>
   </xs:element>
+  <xs:attributeGroup name="ref_attr">
+    <xs:attribute name="name" use="required" type="ns1:identifier"/>
+    <xs:attribute name="id" use="required" type="xs:anyURI"/>
+    <xs:attribute name="version" use="required" type="ns1:version_num_ref"/>
+    <xs:attribute name="interpretation"/>
+  </xs:attributeGroup>
   <!-- ==================== declared constants =========================== -->
   <xs:element name="declared_const_set">
     <xs:complexType>
@@ -127,12 +126,12 @@
           <xs:element ref="ns1:sequence"/>
           <xs:element ref="ns1:fixed_field"/>
           <xs:element ref="ns1:variable_field"/>
-          <xs:element ref="ns1:value_set"/>
           <xs:element ref="ns1:bit_field"/>
           <xs:element ref="ns1:fixed_length_string"/>
           <xs:element ref="ns1:variable_length_string"/>
           <xs:element ref="ns1:variable_length_field"/>
           <xs:element ref="ns1:variable_format_field"/>
+          <xs:element ref="ns1:value_set"/>
           <xs:element ref="ns1:declared_message_def"/>
           <xs:element ref="ns1:declared_event_def"/>
           <xs:element ref="ns1:declared_header"/>
@@ -197,7 +196,7 @@
   <xs:element name="declared_variant">
     <xs:complexType>
       <xs:attributeGroup ref="ns1:attribute_declared_type"/>
-      <xs:attribute name="optional" type="xs:boolean"/>
+      <xs:attribute name="optional" use="required" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="declared_sequence">
@@ -529,8 +528,10 @@
     <xs:complexType>
       <xs:choice minOccurs="0">
         <xs:element ref="ns1:scale_range"/>
-        <xs:element ref="ns1:value_set"/>
-        <xs:element ref="ns1:declared_value_set"/>
+        <xs:choice>
+          <xs:element ref="ns1:value_set"/>
+          <xs:element ref="ns1:declared_value_set"/>
+        </xs:choice>
       </xs:choice>
       <xs:attribute name="name" use="required" type="ns1:identifier"/>
       <xs:attributeGroup ref="ns1:attribute_field_type"/>
@@ -541,19 +542,13 @@
   </xs:element>
   <xs:element name="variable_field">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="ns1:type_and_units_field"/>
-      </xs:sequence>
-      <xs:attribute name="name" use="required" type="ns1:identifier"/>
-      <xs:attribute name="optional" use="required" type="xs:boolean"/>
-      <xs:attribute name="interpretation"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="type_and_units_field">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="ns1:type_and_units_enum"/>
-      </xs:sequence>
+      <xs:complexContent>
+        <xs:extension base="ns1:type_and_units_field">
+          <xs:attribute name="name" use="required" type="ns1:identifier"/>
+          <xs:attribute name="optional" use="required" type="xs:boolean"/>
+          <xs:attribute name="interpretation"/>
+        </xs:extension>
+      </xs:complexContent>
     </xs:complexType>
   </xs:element>
   <xs:element name="bit_field">
@@ -656,6 +651,18 @@
       <xs:attribute name="interpretation"/>
     </xs:complexType>
   </xs:element>
+  <xs:complexType name="type_and_units_field">
+    <xs:sequence>
+      <xs:element ref="ns1:type_and_units_field"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="type_and_units_field">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="ns1:type_and_units_enum"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
   <xs:element name="format_field">
     <xs:complexType>
       <xs:sequence>
@@ -704,6 +711,7 @@
         <xs:restriction base="xs:token">
           <xs:enumeration value="meter"/>
           <xs:enumeration value="kilogram"/>
+          <xs:enumeration value="second"/>
           <xs:enumeration value="ampere"/>
           <xs:enumeration value="kelvin"/>
           <xs:enumeration value="mole"/>
@@ -755,6 +763,7 @@
           <xs:enumeration value="joule per kelvin"/>
           <xs:enumeration value="joule per kilogram"/>
           <xs:enumeration value="kelvin"/>
+          <xs:enumeration value="joule per kilogram"/>
           <xs:enumeration value="watt per meter kelvin"/>
           <xs:enumeration value="joule per cubic meter"/>
           <xs:enumeration value="volt per meter"/>
@@ -789,7 +798,7 @@
           <xs:enumeration value="are"/>
           <xs:enumeration value="hectare"/>
           <xs:enumeration value="bar"/>
-          <xs:enumeration value="�ngstro"/>
+          <xs:enumeration value="ångstro"/>
           <xs:enumeration value="barn"/>
           <xs:enumeration value="curie"/>
           <xs:enumeration value="roentgen"/>
@@ -802,8 +811,10 @@
   <xs:element name="type_and_units_enum">
     <xs:complexType>
       <xs:choice minOccurs="0">
-        <xs:element ref="ns1:value_set"/>
-        <xs:element ref="ns1:declared_value_set"/>
+        <xs:choice>
+          <xs:element ref="ns1:value_set"/>
+          <xs:element ref="ns1:declared_value_set"/>
+        </xs:choice>
         <xs:element ref="ns1:scale_range"/>
       </xs:choice>
       <xs:attribute name="name" use="required" type="ns1:identifier"/>
@@ -822,7 +833,6 @@
       <xs:attributeGroup ref="ns1:attribute_field_format"/>
     </xs:complexType>
   </xs:element>
-  <!-- Name attribute added in REV_A of JSIDL 1.0 -->
   <xs:element name="value_set">
     <xs:complexType>
       <xs:choice maxOccurs="unbounded">
@@ -905,7 +915,7 @@
   <xs:element name="state_machine">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="ns1:state"/>
+        <xs:element maxOccurs="unbounded" ref="ns1:state"/>
         <xs:element minOccurs="0" ref="ns1:default_state"/>
         <xs:element minOccurs="0" ref="ns1:pseudo_start_state"/>
         <xs:element minOccurs="0" ref="plus:mxCell"/>
@@ -1103,13 +1113,17 @@
       <xs:pattern value="[a-zA-Z_][a-zA-Z_0-9]*"/>
     </xs:restriction>
   </xs:simpleType>
-  <!-- namespaced identifier ( identifier(.identifier)* ) -->
+  <!--
+    namespaced identifier ( identifier(.identifier)* ). Dot (“.”) is the namespace 
+    operator. It must be used to qualify a namespace. It must not be used 
+    as part of the identifier itself.
+  -->
   <xs:simpleType name="identifier_ns">
     <xs:restriction base="xs:string">
       <xs:pattern value="[a-zA-Z_][a-zA-Z_0-9.]*"/>
     </xs:restriction>
   </xs:simpleType>
-  <!-- param type -->
+  <!-- parameter type -->
   <xs:simpleType name="param_type">
     <xs:union>
       <xs:simpleType>

--- a/GUI/resources/schema/JSIDL_Plus/plus.xsd
+++ b/GUI/resources/schema/JSIDL_Plus/plus.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:jaus:jsidl:plus" xmlns:plus="urn:jaus:jsidl:plus" xmlns:ns1="urn:jaus:jsidl:1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="urn:jaus:jsidl:plus" xmlns:ns1="urn:jaus:jsidl:1.1" xmlns:plus="urn:jaus:jsidl:plus">
   <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
   <xs:import namespace="urn:jaus:jsidl:1.1" schemaLocation="jsidl_plus.xsd"/>
   <xs:element name="service_set">

--- a/GUI/resources/schema/JSIDL_Plus/xml.xsd
+++ b/GUI/resources/schema/JSIDL_Plus/xml.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:plus="urn:jaus:jsidl:plus" xmlns:ns1="urn:jaus:jsidl:1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:ns1="urn:jaus:jsidl:1.1" xmlns:plus="urn:jaus:jsidl:plus">
   <xs:import namespace="urn:jaus:jsidl:1.1" schemaLocation="jsidl_plus.xsd"/>
   <xs:import namespace="urn:jaus:jsidl:plus" schemaLocation="plus.xsd"/>
   <xs:attribute name="space">

--- a/GUI/src/org/jts/gui/exportJSIDL/Export.java
+++ b/GUI/src/org/jts/gui/exportJSIDL/Export.java
@@ -307,11 +307,11 @@ public class Export {
             //Handle Eclipse plugin's handling of relative paths
             if(new File("plugins/org.jts.eclipse.data_1.0/resources").exists())
             {
-                schema =  sf.newSchema(new File("plugins/org.jts.eclipse.data_1.0/resources/schema/JSIDL_Plus/version_1_1.xsd"));
+                schema =  sf.newSchema(new File("plugins/org.jts.eclipse.data_1.0/resources/schema/JSIDL_Plus/jsidl_plus.xsd"));
             }
             else
             {
-                schema =  sf.newSchema(new File("resources/schema/JSIDL_Plus/version_1_1.xsd"));
+                schema =  sf.newSchema(new File("resources/schema/JSIDL_Plus/jsidl_plus.xsd"));
             }
 
             m.setSchema(schema);

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java
@@ -266,12 +266,7 @@ public class DeclaredTypeMap {
             org.jts.jsidl.binding.Variant element_copy = new org.jts.jsidl.binding.Variant();
 
             element_copy.setName(declaredVariant.getName());
-            
-			if (declaredVariant.isOptional() != null) {
-                element_copy.setOptional(declaredVariant.isOptional());
-            } else {
-                element_copy.setOptional(element.isOptional());
-            }
+            element_copy.setOptional(declaredVariant.isOptional());
 
             if (declaredVariant.getInterpretation() != null) {
                 element_copy.setInterpretation(declaredVariant.getInterpretation());

--- a/eclipsePlugin/org.jts.eclipse.data_1.0/resources/docGenerator/linearHTMLStyles/servdef_jsidl_db_cals.xsl
+++ b/eclipsePlugin/org.jts.eclipse.data_1.0/resources/docGenerator/linearHTMLStyles/servdef_jsidl_db_cals.xsl
@@ -18,7 +18,7 @@
 <xsl:stylesheet
     xmlns="http://docbook.org/ns/docbook"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
-    xmlns:jaus="urn:jaus:jsidl:1.0"
+    xmlns:jaus="urn:jaus:jsidl:1.1"
     xmlns:x="http://www.w3.org/1999/xhtml">
 
   <!--

--- a/eclipsePlugin/org.jts.eclipse.data_1.0/resources/docGenerator/wordStyles/servdef_jsidl_db_cals.xsl
+++ b/eclipsePlugin/org.jts.eclipse.data_1.0/resources/docGenerator/wordStyles/servdef_jsidl_db_cals.xsl
@@ -19,7 +19,7 @@
 <xsl:stylesheet
     xmlns="http://docbook.org/ns/docbook"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
-    xmlns:jaus="urn:jaus:jsidl:1.0"
+    xmlns:jaus="urn:jaus:jsidl:1.1"
     xmlns:x="http://www.w3.org/1999/xhtml">
 
   <!--

--- a/promelaCodeGenerator/src/org/jts/protocolvalidator/DefinitionFinder.java
+++ b/promelaCodeGenerator/src/org/jts/protocolvalidator/DefinitionFinder.java
@@ -331,7 +331,7 @@ public class DefinitionFinder {
         // getting the id from the file
         Element root = doc.getDocumentElement();
 
-        if (root.getAttribute("xmlns").equals("urn:jaus:jsidl:1.0")) {
+        if (root.getAttribute("xmlns").equals("urn:jaus:jsidl:1.1")) {
             id = root.getAttribute("id");
         }
 

--- a/promelaCodeGenerator/src/org/jts/protocolvalidator/DefinitionFinder.java
+++ b/promelaCodeGenerator/src/org/jts/protocolvalidator/DefinitionFinder.java
@@ -420,7 +420,7 @@ public class DefinitionFinder {
             // getting the id from the file
             Element root = doc.getDocumentElement();
 
-            if (root.getAttribute("xmlns").equals("urn:jaus:jsidl:1.0")) {
+            if (root.getAttribute("xmlns").equals("urn:jaus:jsidl:1.1")) {
                 JSIDLReader reader = new JSIDLReader(fileName, schemaPath);
                 Object rootObj = reader.getRootElement();
                 if (rootObj instanceof ServiceDef) {

--- a/promelaCodeGenerator/src/org/jts/protocolvalidator/FileFinder.java
+++ b/promelaCodeGenerator/src/org/jts/protocolvalidator/FileFinder.java
@@ -214,7 +214,7 @@ public class FileFinder {
             Element root = doc.getDocumentElement();
             id = root.getAttribute("id");
 
-            if (root.getAttribute("xmlns").equals("urn:jaus:jsidl:1.0") && !id.isEmpty()) {
+            if (root.getAttribute("xmlns").equals("urn:jaus:jsidl:1.1") && !id.isEmpty()) {
                 fileMap.put(fileName, root.getAttribute("id"));
                 reverseFileMap.put(root.getAttribute("id"), fileName);
             }


### PR DESCRIPTION
Updates to support JSIDL 1.1.

@dvmartin999 -  These are some of the changes I had on my JSIDL 1.1 branch
that should probably be pulled into your branch. Additionally, I have updated the 
JSIDL schema to be closer to the AS5684 document by making the optional 
attribute on the declared_variant required. I've updated Import.java to handle
backwards compatibility. 

NOTE: xsd files were regenerated using trang from the rnc files.

  * Import.java
    - Updated the getObjectMap() method to fix importing JSIDL 1.0 with
      declared_variant elements that do NOT have the 'optional' attribute.
      The 'optional' attribute is required in JSIDL 1.1. This is a hack
      will add the 'optional' attribute if it doesn't exist for JSIDL 1.0.
    - Tested by modifying
      GUI/resources/xml/urn.jaus.jss.hmi/MessageSet/InformClass.xml
      to remove some of the 'optional' attributes from 'declared_variant'
      elements. Without this code change, JTS will report that the
      JSIDL is invalid. With the change, the JSIDL is imported without
      reporting any errors.
  * Export.java:
    - Needed to update exportServiceDefJSIDL() to use 'jsidl_plus.xsd'
      since 'version_1_1.xsd' no longer exists.
  * DeclaredTypeMap.java:
    - Remove check to see if declaredVariant.isOptional() != null. The
      'optional' attribute is required in JSIDL 1.1. The code should
      reflect that. As such, the isOptional field is a boolean not a
      Boolean and cannot be null.
  * eclipsePlugin/.../servdef_jsidl_db_cals.xsl
    - Updated to use JSIDL 1.1 to be consistent. Is anyone using
      the Eclispe plugin?
  * DefinitionFinder.java:
    - Updated to look for 'urn:jaus:jsidl:1.1'
  * FileFinder.java:
    - Updated to look for 'urn:jaus:jsidl:1.1'
  * jsidl.rnc:
    - Updated to make ref_attr have a separate definition to match
      AS5684 document.
  * jsidl_plus.rnc
    - Updated to make ref_attr have a separate definition to match
      AS5684.
    - Updated the declared_variant to make the optional attribute
      required to be consistent with JSIDL 1.1. We shouldn't loosen
      the requirements unless we plan to integrate that back into
      the standard. If we're concerned with importing 1.0 JSIDL,
      then we should handle that separately.
    - Updated the state_machine to have at least one state to
      match the AS5684 document.
    - Updated variable_field to define type_and_units_field inline
      because defining it separately causes problems in the XSD.
  * jsidl_plus.xsd
    - Regenerated using the updated jsidl_plus.rnc (using trang)
    - In addition to the changes above, it looks like the
      field_units attribute was missing some enumerations.

