### PR TITLE
Support for resolving declared_value_set on import

### DIFF
--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/Array.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/Array.java
@@ -202,6 +202,19 @@ public class Array
 				jxArray.setVariableLengthString(element);
 			}
 		}
+		// bit, fixed, and variable fields can all have embedded declared_value_set, so we need to resolve them
+		else if(jxArray.getBitField() != null)
+		{
+			BitField.resolveDeclaredElements(jxArray.getBitField());
+		}
+		else if(jxArray.getFixedField() != null)
+		{
+			FixedField.resolveDeclaredElements(jxArray.getFixedField());
+		}
+		else if(jxArray.getVariableField() != null)
+		{
+			VariableField.resolveDeclaredElements(jxArray.getVariableField());
+		}
 	}
 
 	public static void resolveDeclaredConstantElements(org.jts.jsidl.binding.Array array)

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/BitField.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/BitField.java
@@ -1,0 +1,75 @@
+/***********           LICENSE HEADER   *******************************
+JAUS Tool Set
+Copyright (c)  2010, United States Government
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+       Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+       Redistributions in binary form must reproduce the above copyright 
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+
+       Neither the name of the United States Government nor the names of 
+its contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+*********************  END OF LICENSE ***********************************/
+
+package org.jts.gui.importJSIDL.declaredElementsResolution;
+
+import org.jts.gui.importJSIDL.ImportException;
+import org.jts.jsidl.binding.*;
+
+public class BitField 
+{
+	public static void importDeclaredType(org.jts.jsidl.binding.BitField jxBitField)
+	{
+		BitField.resolveDeclaredElements(jxBitField);		
+		// Add this element to the current map
+		DeclaredTypeMap declaredTypeMap = DeclaredTypeMap.getInstance();
+		declaredTypeMap.addType(jxBitField.getName(), jxBitField);
+	}
+
+	public static void resolveDeclaredElements(org.jts.jsidl.binding.BitField jxBitField) 
+	{
+		// Resolve any internal declared types in the subfield
+        for (SubField subfield : jxBitField.getSubField() )
+        {
+            if (subfield.getDeclaredValueSet() != null)
+            {
+                // Resolve the declared type into the actual object
+			    org.jts.jsidl.binding.DeclaredValueSet declaredValueSet = subfield.getDeclaredValueSet();
+			    org.jts.jsidl.binding.ValueSet element = DeclaredTypeMap.lookupDeclaredValueSet(declaredValueSet);
+			
+			    if(element == null)
+			    {
+				    // Error, not found in TypeMap
+				    throw new ImportException("Declared Value Set \""+declaredValueSet.getName()+"\" with type ref \""+declaredValueSet.getDeclaredTypeRef()+"\" not found.");
+			    }
+			    else
+			    {
+				    // Remove from the array
+				    subfield.setDeclaredValueSet(null);
+
+				    // Add to the array
+				    subfield.setValueSet(element);
+			    }
+            }
+        }
+	}
+}

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java
@@ -850,4 +850,32 @@ public class DeclaredTypeMap {
             return element_copy;
         }
     }
+
+    public static org.jts.jsidl.binding.ValueSet lookupDeclaredValueSet(org.jts.jsidl.binding.DeclaredValueSet declaredValueSet) {
+        DeclaredTypeMap declaredTypeMap = DeclaredTypeMap.getInstance();
+
+        Object obj = declaredTypeMap.getType(declaredValueSet.getDeclaredTypeRef());
+
+        if (obj == null) {
+            // Error, declared type ref not found in TypeMap
+            return null;
+        } else if (!(obj instanceof org.jts.jsidl.binding.ValueSet)) {
+            // Error, declared type ref found but wrong object type
+            return null;
+        } else {
+        	
+            org.jts.jsidl.binding.ValueSet element = (org.jts.jsidl.binding.ValueSet) obj;
+        	org.jts.jsidl.binding.ValueSet element_copy = new org.jts.jsidl.binding.ValueSet();
+
+        	element_copy.setName(declaredValueSet.getName());
+            element_copy.setOffsetToLowerLimit(element.isOffsetToLowerLimit());
+            for (Object item : element.getValueRangeOrValueEnum()) {
+                element_copy.getValueRangeOrValueEnum().add(item);
+            } 
+
+            return element_copy;
+        }
+    }
+
+    
 }

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeSet.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeSet.java
@@ -335,6 +335,14 @@ public class DeclaredTypeSet
 		{
 			mapDeclaredVariableLengthString(obj, declaredTypeMap);
 		}
+		else if(obj instanceof org.jts.jsidl.binding.DeclaredValueSet)
+		{
+			mapDeclaredValueSet(obj, declaredTypeMap);
+		}
+		else if(obj instanceof org.jts.jsidl.binding.ValueSet)
+		{
+			mapValueSet(obj, declaredTypeMap);
+		}
 		else
 		{
 			// Unknown type
@@ -378,8 +386,8 @@ public class DeclaredTypeSet
 	
 	public static void mapBitField(Object obj, DeclaredTypeMap declaredTypeMap)
 	{
-		// No possible declared types to resolve in BitField, so add this object to the map
 		org.jts.jsidl.binding.BitField field = (org.jts.jsidl.binding.BitField) obj;
+        BitField.resolveDeclaredElements(field);
 		declaredTypeMap.addType(field.getName(), field);
 	}
 	
@@ -390,9 +398,8 @@ public class DeclaredTypeSet
 	
 	public static void mapVariableField(Object obj, DeclaredTypeMap declaredTypeMap)
 	{
-		// No possible declared types to resolve in VariableField, so add this object to the map
 		org.jts.jsidl.binding.VariableField field = (org.jts.jsidl.binding.VariableField) obj;
-
+		VariableField.resolveDeclaredElements(field);
 		declaredTypeMap.addType(field.getName(), field);
 	}
 	
@@ -410,8 +417,8 @@ public class DeclaredTypeSet
 	
 	public static void mapFixedField(Object obj, DeclaredTypeMap declaredTypeMap)
 	{
-		// No possible declared types to resolve in FixedField, so add this object to the map
 		org.jts.jsidl.binding.FixedField fixedField = (org.jts.jsidl.binding.FixedField) obj;
+		FixedField.resolveDeclaredElements(fixedField);
 		declaredTypeMap.addType(fixedField.getName(), fixedField);
 	}
 	
@@ -751,6 +758,31 @@ public class DeclaredTypeSet
 		{
 			// Add to the map with the declared name
 			declaredTypeMap.addType(declaredVariableLengthString.getName(), element);
+		}
+	}
+
+    public static void mapValueSet(Object obj, DeclaredTypeMap declaredTypeMap)
+	{
+		// No possible declared types to resolve in ValueSet, so add this object to the map
+		org.jts.jsidl.binding.ValueSet field = (org.jts.jsidl.binding.ValueSet) obj;
+		declaredTypeMap.addType(field.getName(), field);
+	}
+	
+	public static void mapDeclaredValueSet(Object obj, DeclaredTypeMap declaredTypeMap)
+	{
+		// Resolve the declared type into the actual object
+		org.jts.jsidl.binding.DeclaredValueSet declaredValueSet = (org.jts.jsidl.binding.DeclaredValueSet) obj;
+		org.jts.jsidl.binding.ValueSet element = DeclaredTypeMap.lookupDeclaredValueSet(declaredValueSet);
+		
+		if(element == null)
+		{
+			// Error, not found in TypeMap
+			throw new ImportException("Declared Value Set \""+declaredValueSet.getName()+"\" with type ref \""+declaredValueSet.getDeclaredTypeRef()+"\" not found.");
+		}
+		else
+		{
+			// Add to the map with the declared name
+			declaredTypeMap.addType(declaredValueSet.getName(), element);
 		}
 	}
 	

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/FixedField.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/FixedField.java
@@ -1,0 +1,72 @@
+/***********           LICENSE HEADER   *******************************
+JAUS Tool Set
+Copyright (c)  2010, United States Government
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+       Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+       Redistributions in binary form must reproduce the above copyright 
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+
+       Neither the name of the United States Government nor the names of 
+its contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+*********************  END OF LICENSE ***********************************/
+
+package org.jts.gui.importJSIDL.declaredElementsResolution;
+
+import org.jts.gui.importJSIDL.ImportException;
+import org.jts.jsidl.binding.*;
+
+public class FixedField 
+{
+	public static void importDeclaredType(org.jts.jsidl.binding.FixedField jxFixedField)
+	{
+		FixedField.resolveDeclaredElements(jxFixedField);		
+		// Add this element to the current map
+		DeclaredTypeMap declaredTypeMap = DeclaredTypeMap.getInstance();
+		declaredTypeMap.addType(jxFixedField.getName(), jxFixedField);
+	}
+
+	public static void resolveDeclaredElements(org.jts.jsidl.binding.FixedField jxFixedField) 
+	{
+		// Resolve any internal declared types
+        if (jxFixedField.getDeclaredValueSet() != null)
+		{
+			// Resolve the declared type into the actual object
+			org.jts.jsidl.binding.DeclaredValueSet declaredValueSet = jxFixedField.getDeclaredValueSet();
+			org.jts.jsidl.binding.ValueSet element = DeclaredTypeMap.lookupDeclaredValueSet(declaredValueSet);
+		
+			if(element == null)
+			{
+				// Error, not found in TypeMap
+				throw new ImportException("Declared Value Set \""+declaredValueSet.getName()+"\" with type ref \""+declaredValueSet.getDeclaredTypeRef()+"\" not found.");
+			}
+			else
+			{
+				// Remove from the array
+				jxFixedField.setDeclaredValueSet(null);
+
+				// Add to the array
+				jxFixedField.setValueSet(element);
+			}
+		}
+	}
+}

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/Record.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/Record.java
@@ -222,6 +222,19 @@ public class Record
 				{
 					Array.resolveDeclaredElements((org.jts.jsidl.binding.Array) obj);
 				}
+				// bit, fixed, and variable fields can all have embedded declared_value_set, so we need to resolve them
+				else if( obj instanceof org.jts.jsidl.binding.BitField )
+				{
+					BitField.resolveDeclaredElements((org.jts.jsidl.binding.BitField) obj);
+				}
+				else if( obj instanceof org.jts.jsidl.binding.FixedField )
+				{
+					FixedField.resolveDeclaredElements((org.jts.jsidl.binding.FixedField) obj);
+				}
+				else if( obj instanceof org.jts.jsidl.binding.VariableField )
+				{
+					VariableField.resolveDeclaredElements((org.jts.jsidl.binding.VariableField) obj);
+				}
 			}
 		}
 	}

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/VariableField.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/VariableField.java
@@ -1,0 +1,78 @@
+/***********           LICENSE HEADER   *******************************
+JAUS Tool Set
+Copyright (c)  2010, United States Government
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+       Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+       Redistributions in binary form must reproduce the above copyright 
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+
+       Neither the name of the United States Government nor the names of 
+its contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+*********************  END OF LICENSE ***********************************/
+
+package org.jts.gui.importJSIDL.declaredElementsResolution;
+
+import org.jts.gui.importJSIDL.ImportException;
+import org.jts.jsidl.binding.*;
+
+public class VariableField 
+{
+	public static void importDeclaredType(org.jts.jsidl.binding.VariableField jxVariableField)
+	{
+		VariableField.resolveDeclaredElements(jxVariableField);		
+		// Add this element to the current map
+		DeclaredTypeMap declaredTypeMap = DeclaredTypeMap.getInstance();
+		declaredTypeMap.addType(jxVariableField.getName(), jxVariableField);
+	}
+
+	public static void resolveDeclaredElements(org.jts.jsidl.binding.VariableField jxVariableField) 
+	{
+		// Resolve any internal declared types in the type and units field
+        if (jxVariableField.getTypeAndUnitsField() != null)
+        {
+			for (TypeAndUnitsEnum type : jxVariableField.getTypeAndUnitsField().getTypeAndUnitsEnum())
+			{
+				if (type.getDeclaredValueSet() != null)
+				{
+					// Resolve the declared type into the actual object
+					org.jts.jsidl.binding.DeclaredValueSet declaredValueSet = type.getDeclaredValueSet();
+					org.jts.jsidl.binding.ValueSet element = DeclaredTypeMap.lookupDeclaredValueSet(declaredValueSet);
+				
+					if(element == null)
+					{
+						// Error, not found in TypeMap
+						throw new ImportException("Declared Value Set \""+declaredValueSet.getName()+"\" with type ref \""+declaredValueSet.getDeclaredTypeRef()+"\" not found.");
+					}
+					else
+					{
+						// Remove from the array
+						type.setDeclaredValueSet(null);
+
+						// Add to the array
+						type.setValueSet(element);
+					}
+				}
+			}
+        }
+	}
+}


### PR DESCRIPTION
Added support for resolving declared_value_set on import.  This impacts how fixed_fields, bit_fields, and variable_fields directly, and array and records indirectly.

Validated by importing the attached XML which exercises all combinations, then exported the JSIDL and verified all references were resolved properly.

[DeclaredValueSetTest.xml.txt](https://github.com/jaustoolset/jaustoolset/files/3317242/DeclaredValueSetTest.xml.txt)

