### PR TITLE
Switch detect duplicates to short for improved handling by XmlConfig.…

### DIFF
--- a/GUI/templates/Common/include/Transport/JuniorMgr.h
+++ b/GUI/templates/Common/include/Transport/JuniorMgr.h
@@ -90,7 +90,7 @@ private:
     // Configuration data
     unsigned short _maxMsgHistory;      // as a message count
     unsigned short _oldMsgTimeout;      // in seconds
-    unsigned char  _detectDuplicates; 
+    unsigned short _detectDuplicates; 
 
 	// We now allow the receive loop to find the ack/nak response,
 	// rather than doing it from the send loop.  But that means

--- a/GUI/templates/Common/include/Transport/XmlConfig.h
+++ b/GUI/templates/Common/include/Transport/XmlConfig.h
@@ -83,15 +83,7 @@ public:
 			  					 const std::string& attribute,
 								 const std::string& element,
 								 int index = 0);
-	virtual ConfigError getValue(char& value,
-			  					 const std::string& attribute,
-								 const std::string& element,
-								 int index = 0);
-	virtual ConfigError getValue(unsigned char& value,
-			  					 const std::string& attribute,
-								 const std::string& element,
-								 int index = 0);
-    virtual ConfigError getValue(double& value,
+	virtual ConfigError getValue(double& value,
 			  					 const std::string& attribute,
 								 const std::string& element,
 								 int index = 0);

--- a/GUI/templates/Common/src/Transport/XmlConfig.cpp
+++ b/GUI/templates/Common/src/Transport/XmlConfig.cpp
@@ -89,22 +89,6 @@ ConfigData::ConfigError XmlConfig::getValue(unsigned short& value,
 	return lookupValue(value, attribute, element, index);
 }
 
-ConfigData::ConfigError XmlConfig::getValue(char& value,
-		  					 const std::string& attribute,
-							 const std::string& element,
-							 int index)
-{
-	return lookupValue(value, attribute, element, index);
-}
-
-ConfigData::ConfigError XmlConfig::getValue(unsigned char& value,
-		  					 const std::string& attribute,
-							 const std::string& element,
-							 int index)
-{
-	return lookupValue(value, attribute, element, index);
-}
-
 ConfigData::ConfigError XmlConfig::getValue(double& value,
 		  					 const std::string& attribute,
 							 const std::string& element,


### PR DESCRIPTION
…  Remove templated functions for char and uchar, since return values were often not as expected.  Code using these templates should switch to ints or strings as needed.