### PR TITLE
Fixed JTS failing to import JSIDL with messages that don't have is_command

### DIFF
--- a/GUI/src/org/jts/codegenerator/MessageDefGenerator.java
+++ b/GUI/src/org/jts/codegenerator/MessageDefGenerator.java
@@ -129,7 +129,7 @@ public class MessageDefGenerator {
                 }
 
                 /// Initialize isCommand variable
-                code.constructorLines.add("m_IsCommand = " + String.valueOf(msgDef.isIsCommand()) + ";");
+                code.constructorLines.add("m_IsCommand = " + String.valueOf(msgDef.isIsCommand() == null ? false : msgDef.isIsCommand()) + ";");
 
                 includes.add("Messages/Message.h");
                 includes.add("JConstants.h");
@@ -202,7 +202,7 @@ public class MessageDefGenerator {
                     code.addAll(subCode);
                 }
                 /// Initialize isCommand variable
-                code.constructorLines.add("m_IsCommand = " + String.valueOf(msgDef.isIsCommand()) + ";");
+                code.constructorLines.add("m_IsCommand = " + String.valueOf(msgDef.isIsCommand() == null ? false : msgDef.isIsCommand()) + ";");
 
                 includes.add("framework.messages.Message");
                 includes.add("framework.JausUtils");
@@ -298,7 +298,7 @@ public class MessageDefGenerator {
                     code.addAll(subCode);
                 }
                 /// Initialize isCommand variable
-                code.constructorLines.add("m_IsCommand = " + String.valueOf(msgDef.isIsCommand()) + ";");
+                code.constructorLines.add("m_IsCommand = " + String.valueOf(msgDef.isIsCommand() == null ? false : msgDef.isIsCommand()) + ";");
 
                 baseClassList.add("JTS.Message");
                 if (!namespace.isEmpty()) {

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/MessageDef.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/MessageDef.java
@@ -77,7 +77,9 @@ public class MessageDef
 			jmMessageDef.getMessageId().setValue(messageId);
 			
 			// isCommand
-			jmMessageDef.getIsCommand().setValue(jxMessageDef.isIsCommand());
+                        /// @TODO The isCommand attribute is optional. However, 
+                        /// the jmMessage does not support optional booleans. 
+			jmMessageDef.getIsCommand().setValue(jxMessageDef.isIsCommand() == null ? false : jxMessageDef.isIsCommand());
 			
 			// Description
 			String description = jxMessageDef.getDescription().getContent().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;			

--- a/GUI/src/org/jts/gui/jmatterToJAXB/MessageDef.java
+++ b/GUI/src/org/jts/gui/jmatterToJAXB/MessageDef.java
@@ -45,6 +45,7 @@ public class MessageDef {
     md.setName( messageDef.getName().toString() );
      
      md.setMessageId( getBytes(messageDef.getMessageId().toString()) );
+     /// @TODO: This should handle null values because the isCommand is optional.
      md.setIsCommand( messageDef.getIsCommand().booleanValue() );
      md.setDescription( Description.convert( messageDef) );
      

--- a/promelaCodeGenerator/src/org/jts/protocolvalidator/DefinitionGenerator.java
+++ b/promelaCodeGenerator/src/org/jts/protocolvalidator/DefinitionGenerator.java
@@ -136,7 +136,7 @@ public class DefinitionGenerator extends JTSFileWriter {
         // get type from reference to the type
         String name = Util.getTypeNameFromDeclTypeRef(refMap, msgDef.getName(), classID);
         refMap.put(msgDef.getName(), name);
-        boolean cmd = msgDef.isIsCommand();
+        boolean cmd = msgDef.isIsCommand() == null ? false : msgDef.isIsCommand();
         waitingOutput.add("typedef " + name + "{");
 
         // definitions and declarations need to be kept separate


### PR DESCRIPTION
Fixed JTS failing to import JSIDL with messages that don't have is_command.

Fixed JTS failing to import JSIDL with messages that don't have is_command.
This attribute is optional. No default is specified, but since it was added
in JSIDL 1.1, I'm going to assume the default is false because messages
defined prior to JSIDL were NOT commands.

The JMatter GUI elements don't support optional fields. It would be nice
to have that option in there. For now, the is_command will be added to
all messages.

Fixed #45.

SIDENOTE:
The JSIDL 1.1 should be updated to indicate a default value for optional
fields.