### PR TITLE
Added support for the deprecated attribute

### DIFF
--- a/GUI/resources/docGenerator/framedHTMLStyles/messageDefFormat.xsl
+++ b/GUI/resources/docGenerator/framedHTMLStyles/messageDefFormat.xsl
@@ -5,7 +5,7 @@
 		<html>
 			<head>
 				<title>
-					<xsl:value-of select="message_def/@name"/>
+					<xsl:value-of select="message_def/@name"/><xsl:if test="message_def/@deprecated='true'"> (Deprecated)</xsl:if>
 				</title>
 				<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
 				<link rel="stylesheet" href="framedStyleSheet.css"/>
@@ -15,7 +15,7 @@
 				<!-- TITLE -->
 				<!-- ===== -->
 				<h1> 
-					<xsl:value-of select="message_def/@name"/>
+					<xsl:value-of select="message_def/@name"/><xsl:if test="message_def/@deprecated='true'"> (Deprecated)</xsl:if>
 				</h1>
 				<h3>
 					ID: <xsl:value-of select="message_def/@message_id"/>

--- a/GUI/resources/docGenerator/framedHTMLStyles/serviceDefFormat.xsl
+++ b/GUI/resources/docGenerator/framedHTMLStyles/serviceDefFormat.xsl
@@ -5,7 +5,7 @@
 		<html>
 			<head>
 				<title>
-					<xsl:value-of select="service_def/@name"/>
+					<xsl:value-of select="service_def/@name"/><xsl:if test="service_def/@deprecated='true'"> (Deprecated)</xsl:if>
 				</title>
 				<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
 				<link rel="stylesheet" href="framedStyleSheet.css"/>
@@ -17,7 +17,7 @@
 				<!-- TITLE -->
 				<!-- ===== -->
 				<h1> 
-					<xsl:value-of select="service_def/@name"/> Service
+					<xsl:value-of select="service_def/@name"/> Service<xsl:if test="service_def/@deprecated='true'"> (Deprecated)</xsl:if>
 				</h1>
 				<br/>
 				
@@ -308,7 +308,7 @@
 			<td align="left">
 				<div>
 					<a href="messages/{$messageName}.html">		<!-- create hyperlink to message file -->
-						<xsl:value-of select="@name"/>
+						<xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if>
 					</a>
 				</div>
 			</td>
@@ -327,7 +327,7 @@
 					<tr>
 						<td align="left">
 							<div>
-								<xsl:value-of select="@name"/>
+								<xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if>
 							</div>
 						</td>
 						<td align="left">
@@ -361,7 +361,7 @@
 		<ul>
 			<h3>
 				<u>
-					<xsl:value-of select="@name"/>
+					<xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if>
 				</u>
 			</h3>
 			

--- a/GUI/resources/docGenerator/framedHTMLStyles/serviceSetFormat.xsl
+++ b/GUI/resources/docGenerator/framedHTMLStyles/serviceSetFormat.xsl
@@ -48,7 +48,7 @@
 				<div>
 					<b>
 						<a href="{$serviceDefName}/{$serviceDefName}.html" onClick="loadSubMenuFrame('{$serviceDefName}/subMenuB.html')">		
-							<xsl:value-of select="@name"/>
+							<xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if>
 						</a>
 					<!--
 						<a href="{$serviceDefName}/{$serviceDefName}.html">

--- a/GUI/resources/docGenerator/linearHTMLStyles/servdef_jsidl_db_cals.xsl
+++ b/GUI/resources/docGenerator/linearHTMLStyles/servdef_jsidl_db_cals.xsl
@@ -59,7 +59,7 @@
     <section xml:id="{$sectname}">
       <xsl:attribute name="version">1.0</xsl:attribute>
       <title>
-        <xsl:value-of select="@name"/>
+        <xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if>
       </title>
       
       <para>
@@ -113,7 +113,7 @@
     <row>
       <entry><xsl:value-of select="@message_id"/></entry>
       <entry><link linkend="{$link-text}"><emphasis role="hyperlink">
-        <xsl:value-of select="@name"/></emphasis></link></entry>
+        <xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if></emphasis></link></entry>
       <entry><xsl:value-of select="@is_command"/></entry>
     </row>
   </xsl:template>
@@ -166,7 +166,7 @@
     <row>
       <entry>
         <link linkend="{$link-text}">
-          <emphasis role="hyperlink"><xsl:value-of select="@name"/></emphasis>
+          <emphasis role="hyperlink"><xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if></emphasis>
         </link>
       </entry>
       <entry><xsl:value-of select="./jaus:description"/></entry>
@@ -375,6 +375,7 @@
   <xsl:template match="jaus:description">
     <section>
       <title>Description</title>
+      <xsl:if test="../@deprecated='true'"><para><emphasis role="bold"><xsl:value-of select="../@name"/> is deprecated and is scheduled to be removed during a future revision.</emphasis></para></xsl:if>
       <para>
         <xsl:value-of select="."/>
       </para>
@@ -434,7 +435,8 @@
         <xsl:value-of select="@name"/>
       </xsl:variable>
       <section xml:id="{$event_def_id}">
-        <title><xsl:value-of select="@name"/></title>
+        <title><xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if></title>
+        <xsl:if test="@deprecated='true'"><para><emphasis role="bold"><xsl:value-of select="@name"/> is deprecated and is scheduled to be removed during a future revision.</emphasis></para></xsl:if>
         <para><xsl:value-of select="jaus:description"/></para>
         <span-wrap class-string="event-def-table">
           <table>
@@ -485,8 +487,9 @@
       <section xml:id="{$msg_def_id}">
         <title>
           <xsl:text>ID </xsl:text><xsl:value-of select="@message_id"/>
-          <xsl:text>: </xsl:text><xsl:value-of select="@name"/>
+          <xsl:text>: </xsl:text><xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if>
         </title>
+        <xsl:if test="@deprecated='true'"><para><emphasis role="bold"><xsl:value-of select="@name"/> is deprecated and is scheduled to be removed during a future revision.</emphasis></para></xsl:if>
         <para><xsl:value-of select="jaus:description"/></para>
       <span-wrap class-string="message-def-table">
         <table>

--- a/GUI/resources/docGenerator/wordStyles/servdef_jsidl_db_cals.xsl
+++ b/GUI/resources/docGenerator/wordStyles/servdef_jsidl_db_cals.xsl
@@ -63,7 +63,7 @@
     <section xml:id="{$sectname}">
       <xsl:attribute name="version">1.0</xsl:attribute>
       <title>
-        <xsl:value-of select="@name"/>
+        <xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if>
       </title>
       
       <para>
@@ -141,7 +141,7 @@
                 <row>
                   <entry><xsl:value-of select="@message_id"/></entry>
                   <entry><link linkend="{$link-text}"><emphasis role="hyperlink">
-                    <xsl:value-of select="@name"/></emphasis></link></entry>
+                    <xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if></emphasis></link></entry>
                   <entry><xsl:value-of select="@is_command"/></entry>
                 </row>
               </xsl:for-each>
@@ -158,7 +158,7 @@
                 <row>
                   <entry><xsl:value-of select="@message_id"/></entry>
                   <entry><link linkend="{$link-text}"><emphasis role="hyperlink">
-                    <xsl:value-of select="@name"/></emphasis></link></entry>
+                    <xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if></emphasis></link></entry>
                   <entry><xsl:value-of select="@is_command"/></entry>
                 </row>
               </xsl:for-each>
@@ -196,7 +196,7 @@
               <row>
                 <entry>
                   <link linkend="{$link-text}">
-                    <emphasis role="hyperlink"><xsl:value-of select="@name"/></emphasis>
+                    <emphasis role="hyperlink"><xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if></emphasis>
                   </link>
                 </entry>
                 <entry><xsl:value-of select="./jaus:description"/></entry>
@@ -383,6 +383,7 @@
   <xsl:template match="jaus:description">
     <section>
       <title>Description</title>
+      <xsl:if test="../@deprecated='true'"><para><emphasis role="bold"><xsl:value-of select="../@name"/> is deprecated and is scheduled to be removed during a future revision.</emphasis></para></xsl:if>
       <para>
         <xsl:value-of select="."/>
       </para>
@@ -471,7 +472,8 @@
         <xsl:value-of select="@name"/>
       </xsl:variable>
       <section xml:id="{$event_def_id}">
-        <title><xsl:value-of select="@name"/></title>
+        <title><xsl:value-of select="@name"/><xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if></title>
+        <xsl:if test="@deprecated='true'"><para><emphasis role="bold"><xsl:value-of select="@name"/> is deprecated and is scheduled to be removed during a future revision.</emphasis></para></xsl:if>
         <para><xsl:value-of select="jaus:description"/></para>
         <table>
           <title><xsl:value-of select="@name"/> Event Encoding</title>
@@ -521,8 +523,9 @@
       <section xml:id="{$msg_def_id}">
         <title>
           <xsl:text>ID </xsl:text><xsl:value-of select="@message_id"/>
-          <xsl:text>: </xsl:text><xsl:value-of select="@name"/>
+          <xsl:text>: </xsl:text><xsl:value-of select="@name"/> <xsl:if test="@deprecated='true'"> (Deprecated)</xsl:if>
         </title>
+        <xsl:if test="@deprecated='true'"><para><emphasis role="bold"><xsl:value-of select="@name"/> is deprecated and is scheduled to be removed during a future revision.</emphasis></para></xsl:if>
         <para><xsl:value-of select="jaus:description"/></para>
       <table>
         <title><xsl:value-of select="@name"/> Message Encoding</title>

--- a/GUI/src/com/u2d/generated/EventDef.java
+++ b/GUI/src/com/u2d/generated/EventDef.java
@@ -38,6 +38,11 @@ public  class EventDef extends AbstractComplexEObject_JTS implements HasHeaderBo
     private final StringEO name = new StringEO();
     public StringEO getName() { return name;}
 
+    // ****** deprecated ******
+    private final BooleanEO deprecated = new BooleanEO();
+    public BooleanEO getDeprecated() { return deprecated;}
+    public void setDeprecated( boolean b ) { deprecated.setValue( b ); }
+
     // ******    description   ******
     private final TextEO description = new TextEO();
     public TextEO getDescription() { return description;}
@@ -86,7 +91,7 @@ public  class EventDef extends AbstractComplexEObject_JTS implements HasHeaderBo
 
  
 /************** Uncomment the following as needed *****************************/
-      public static String[] fieldOrder  = {"name", "description", "header", "body", "footer", "referencingServiceDef"};
+      public static String[] fieldOrder  = {"name", "deprecated", "description", "header", "body", "footer", "referencingServiceDef"};
 //    public static String[] fieldOrder        = {"fieldname1", "fieldname2"};
 
       ;

--- a/GUI/src/com/u2d/generated/MessageDef.java
+++ b/GUI/src/com/u2d/generated/MessageDef.java
@@ -56,6 +56,10 @@ public  class MessageDef extends AbstractComplexEObject_JTS implements HasHeader
     public BooleanEO getIsCommand() { return isCommand;}
     public void setIsCommand( boolean b ) { isCommand.setValue( b ); }
 
+    // ******    deprecated   ******
+    private final BooleanEO deprecated = new BooleanEO();
+    public BooleanEO getDeprecated() { return deprecated;}
+    public void setDeprecated( boolean b ) { deprecated.setValue( b ); }
    
 
 
@@ -102,7 +106,7 @@ public  class MessageDef extends AbstractComplexEObject_JTS implements HasHeader
 
  
 /************** Uncomment the following as needed *****************************/
-      public static String[] fieldOrder  = {"name", "messageId", "description", "isCommand", "header", "body", "footer", "referencingElements"};
+      public static String[] fieldOrder  = {"name", "messageId", "description", "isCommand", "deprecated", "header", "body", "footer", "referencingElements"};
 public static String[] readOnly  = {"referencingElements"};
 // ******    referencingElements   ******
    private final StringEO referencingElements = new StringEO("{Input Sets, Output Sets}");

--- a/GUI/src/com/u2d/generated/ServiceDef.java
+++ b/GUI/src/com/u2d/generated/ServiceDef.java
@@ -49,6 +49,11 @@ public  class ServiceDef extends AbstractComplexEObject_JTS{
     @Fld(label="Version")
     public StringEO get_version() { return _version;}
 
+    // ****** deprecated ******
+    private final BooleanEO deprecated = new BooleanEO();
+    public BooleanEO getDeprecated() { return deprecated;}
+    public void setDeprecated( boolean b ) { deprecated.setValue( b ); }
+
     // ******    description   ******
     private final TextEO description = new TextEO();
     public TextEO getDescription() { return description;}
@@ -178,7 +183,7 @@ public  class ServiceDef extends AbstractComplexEObject_JTS{
     }
  
 /************** Uncomment the following as needed *****************************/
-      public static String[] fieldOrder  = {"name", "serviceId", "_version", "description", "assumptions", "inheritsFrom", "clientOf", "inputSet", "outputSet", "eventDefs", "protocolBehavior", "constantSet", "referencingElements"};
+      public static String[] fieldOrder  = {"name", "serviceId", "_version", "deprecated", "description", "assumptions", "inheritsFrom", "clientOf", "inputSet", "outputSet", "eventDefs", "protocolBehavior", "constantSet", "referencingElements"};
 public static String[] readOnly  = {"referencingElements"};
 // ******    referencingElements   ******
    private final StringEO referencingElements = new StringEO("{ServiceDefs (clientOf, InheritsFrom), Service Sets}");

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/EventDef.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/EventDef.java
@@ -66,6 +66,9 @@ public class EventDef
 			// Set Name
 			jmEventDef.getName().setValue(jxEventDef.getName());
 
+                        // deprecated
+                        jmEventDef.getDeprecated().setValue(jxEventDef.isDeprecated() == null ? false : jxEventDef.isDeprecated());
+
 			// Description
 	    	String description = jxEventDef.getDescription().getContent().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
 			jmEventDef.getDescription().setValue(description);

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/MessageDef.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/MessageDef.java
@@ -79,6 +79,9 @@ public class MessageDef
 			// isCommand
 			jmMessageDef.getIsCommand().setValue(jxMessageDef.isIsCommand());
 			
+                        // deprecated
+                        jmMessageDef.getDeprecated().setValue(jxMessageDef.isDeprecated() == null ? false : jxMessageDef.isDeprecated());
+                        
 			// Description
 			String description = jxMessageDef.getDescription().getContent().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;			
 			jmMessageDef.getDescription().setValue(description);

--- a/GUI/src/org/jts/gui/JAXBtoJmatter/ServiceDef.java
+++ b/GUI/src/org/jts/gui/JAXBtoJmatter/ServiceDef.java
@@ -93,6 +93,9 @@ public class ServiceDef
         // version
         jmServiceDef.get_version().setValue( jxServiceDef.getVersion() );
         
+        // deprecated
+        jmServiceDef.getDeprecated().setValue( jxServiceDef.isDeprecated() == null ? false : jxServiceDef.isDeprecated());
+
         // description
         String description = jxServiceDef.getDescription().getContent().replaceAll("\\s\\s+ | \\n | \\r | \\t", " ").trim();;
         jmServiceDef.getDescription().setValue(description);

--- a/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java
+++ b/GUI/src/org/jts/gui/importJSIDL/declaredElementsResolution/DeclaredTypeMap.java
@@ -469,6 +469,7 @@ public class DeclaredTypeMap {
             org.jts.jsidl.binding.EventDef element_copy = new org.jts.jsidl.binding.EventDef();
 
             element_copy.setName(declaredEventDef.getName());
+            element_copy.setDeprecated(element.isDeprecated());
             element_copy.setDescription(element.getDescription());
             element_copy.setHeader(element.getHeader());
             element_copy.setBody(element.getBody());
@@ -680,6 +681,7 @@ public class DeclaredTypeMap {
         	element_copy.setFooter( element.getFooter() );
         	element_copy.setHeader( element.getHeader() );
         	element_copy.setIsCommand( element.isIsCommand() );
+                element_copy.setDeprecated( element.isDeprecated() );
         	element_copy.setMessageId( element.getMessageId() );
 
         	fixOverrides(declaredMessageDef, element_copy);

--- a/GUI/src/org/jts/gui/jmatterToJAXB/EventDef.java
+++ b/GUI/src/org/jts/gui/jmatterToJAXB/EventDef.java
@@ -44,6 +44,8 @@ public class EventDef {
     
      ed.setName( eventDef.getName().toString() );
 
+     ed.setDeprecated( eventDef.getDeprecated().booleanValue() ? true : null );
+
      ed.setDescription( Description.convert( eventDef ) );
      
      // header

--- a/GUI/src/org/jts/gui/jmatterToJAXB/MessageDef.java
+++ b/GUI/src/org/jts/gui/jmatterToJAXB/MessageDef.java
@@ -46,6 +46,7 @@ public class MessageDef {
      
      md.setMessageId( getBytes(messageDef.getMessageId().toString()) );
      md.setIsCommand( messageDef.getIsCommand().booleanValue() );
+     md.setDeprecated( messageDef.getDeprecated().booleanValue() ? true : null);
      md.setDescription( Description.convert( messageDef) );
      
      // header

--- a/GUI/src/org/jts/gui/jmatterToJAXB/ServiceDef.java
+++ b/GUI/src/org/jts/gui/jmatterToJAXB/ServiceDef.java
@@ -47,6 +47,7 @@ public class ServiceDef {
     sd.setName( serviceDef.getName().toString() );
     sd.setId( serviceDef.getServiceId().toString() );
     sd.setVersion( serviceDef.get_version().toString() );
+    sd.setDeprecated( serviceDef.getDeprecated().booleanValue() ? true : null );
     
     // description
     sd.setDescription( Description.convert( serviceDef ) );

--- a/GUI/src/org/jts/validator/MessageDef.java
+++ b/GUI/src/org/jts/validator/MessageDef.java
@@ -175,6 +175,7 @@ public class MessageDef
 					existingMessage.setFooter( messageDef.getFooter() );
 					existingMessage.setHeader( messageDef.getHeader() );
 					existingMessage.setIsCommand( messageDef.getIsCommand().booleanValue() );
+                                        existingMessage.setDeprecated( messageDef.getDeprecated().booleanValue() );
 					existingMessage.setName( messageDef.getName().stringValue() );
 
 					// change item in database


### PR DESCRIPTION
Added support for the deprecated attribute on service_def, message_def, and
event_def. Updated the document generation to add (Deprecated) to services,
messages, and events. We probably could get fancy and add an info box as
well.

The important thing is the JSIDL now maintains the deprecated attribute. The
user can also set an item deprecated in the GUI.

Some of the auto generated code has problems with the line endings are changed:
```
GUI/src/com/u2d/generated/EventDef.java
GUI/src/com/u2d/generated/MessageDef.java
GUI/src/com/u2d/generated/ServiceDef.java
```

The FindReplace helper class does not correctly handle matches with newlines. A
separate issues has been submitted to GitHub for to fix this.

Fixed #46. See #48.