### PR TITLE
Fixed #54. Updated code gen to support service id and version.

### DIFF
--- a/GUI/src/org/jts/codegenerator/ProtocolBehaviorGenerator.java
+++ b/GUI/src/org/jts/codegenerator/ProtocolBehaviorGenerator.java
@@ -596,6 +596,24 @@ public class ProtocolBehaviorGenerator {
         replaceTable.put("%statemachine_name%", smName);
         replaceTable.put("%transport_class_aliases%", smAliases.toString());
         replaceTable.put("%statemachine_name_allcaps%", smName.toUpperCase());
+        
+        replaceTable.put("%service_id%", sd.getId());
+        replaceTable.put("%service_version%", sd.getVersion());
+        int majorVersion = 0;
+        int minorVersion = 0;
+
+        try {
+            String[] version = sd.getVersion().split("\\.");
+            if (version.length > 0) {
+                majorVersion = Integer.parseInt(version[0]);
+            }
+            if (version.length > 1) {
+                minorVersion = Integer.parseInt(version[1]);
+            }
+        } catch (Exception e) {
+        }
+        replaceTable.put("%service_major_version%", Integer.toString(majorVersion));
+        replaceTable.put("%service_minor_version%", Integer.toString(minorVersion));
 
         //---------------------------
         // Generate references to all parent FSMs

--- a/GUI/src/org/jts/codegenerator/ServiceDefGenerator.java
+++ b/GUI/src/org/jts/codegenerator/ServiceDefGenerator.java
@@ -89,6 +89,25 @@ public class ServiceDefGenerator
 		replaceTable.put("%service_namespace%", namespace);
 		replaceTable.put("%service_name%", serviceName);	
 		replaceTable.put("%service_name_allcaps%", serviceName.toUpperCase());
+                replaceTable.put("%service_id%", sDef.getId());
+                replaceTable.put("%service_version%", sDef.getVersion());
+                
+                int majorVersion = 0;
+                int minorVersion = 0;
+
+                try {
+                    String[] version = sDef.getVersion().split("\\.");
+                    if (version.length > 0) {
+                        majorVersion = Integer.parseInt(version[0]);
+                    }
+                    if (version.length > 1) {
+                        minorVersion = Integer.parseInt(version[1]);
+                    }
+                } catch (Exception e) {
+                }
+                replaceTable.put("%service_major_version%", Integer.toString(majorVersion));
+                replaceTable.put("%service_minor_version%", Integer.toString(minorVersion));
+                
 	}
 
 	/*


### PR DESCRIPTION
Fixed #54. Updated the code generator to support replacing the
service id an version. The code generator currently converts
the ID and the version for the service definition into a
language specific namespace. However, some users may want to
put the id or the version from the JSIDL into the code regardless
of the language. This could allow the service template to be
updated to register the service with a Discovery manager.

These changes add the ability to use the following in the service
and protocol behavior templates:
  * %service_id%
  * %service_version%
  * %service_major_version%
  * %service_minor_version%

See #54.