### PR TITLE
Updated JTS Common C++ code to have const getters.

### DIFF
--- a/GUI/templates/Common/include/InternalEvents/InternalEvent.h
+++ b/GUI/templates/Common/include/InternalEvents/InternalEvent.h
@@ -42,16 +42,17 @@ class InternalEvent
 {
 public:
 	InternalEvent(){}
-	InternalEvent( std::string name, std::string source )
+	InternalEvent(const std::string& name, const std::string& source )
 	{
 		m_Name = name;
-	    m_Source = source;
+		m_Source = source;
 	};
-    virtual ~InternalEvent(){};
-	jVariableLengthString getName() { return m_Name; };
-	jVariableLengthString getSource() { return m_Source; };
+	virtual ~InternalEvent(){};
 
-	virtual const unsigned int getSize(){return 0;};
+	jVariableLengthString getName() const { return m_Name; };
+	jVariableLengthString getSource() const { return m_Source; };
+
+	virtual const unsigned int getSize() const {return 0;};
 	virtual void encode(unsigned char *bytes){};
 	virtual void decode(const unsigned char *bytes){};
 	

--- a/GUI/templates/Common/include/InternalEvents/Receive_1_0.h
+++ b/GUI/templates/Common/include/InternalEvents/Receive_1_0.h
@@ -55,7 +55,7 @@ public:
 				const jUnsignedInteger getLength() const;
 				const unsigned char *getData() const;
 				int set(const jUnsignedInteger &length, const unsigned char *data);
-				const unsigned int getSize();
+				const unsigned int getSize() const;
 				virtual void encode(unsigned char *bytes);
 				virtual void decode(const unsigned char *bytes);
 				MessagePayload &operator=(const MessagePayload &value);
@@ -70,15 +70,16 @@ public:
 				unsigned char *m_Data;
 			};
 		
-			jUnsignedShortInteger getSrcSubsystemID();
+			jUnsignedShortInteger getSrcSubsystemID() const;
 			int setSrcSubsystemID(jUnsignedShortInteger value);
-			jUnsignedByte getSrcNodeID();
+			jUnsignedByte getSrcNodeID() const;
 			int setSrcNodeID(jUnsignedByte value);
-			jUnsignedByte getSrcComponentID();
+			jUnsignedByte getSrcComponentID() const;
 			int setSrcComponentID(jUnsignedByte value);
 			MessagePayload* const getMessagePayload();
+			const MessagePayload* const getMessagePayload() const;
 			int setMessagePayload(const MessagePayload &value);
-			const unsigned int getSize();
+			const unsigned int getSize() const;
 			virtual void encode(unsigned char *bytes);
 			virtual void decode(const unsigned char *bytes);
 			ReceiveRec &operator=(const ReceiveRec &value);
@@ -96,8 +97,9 @@ public:
 		};
 	
 		ReceiveRec* const getReceiveRec();
+		const ReceiveRec* const getReceiveRec() const;
 		int setReceiveRec(const ReceiveRec &value);
-		const unsigned int getSize();
+		const unsigned int getSize() const;
 		virtual void encode(unsigned char *bytes);
 		virtual void decode(const unsigned char *bytes);
 		Body &operator=(const Body &value);
@@ -112,8 +114,9 @@ public:
 	};
 
 	Body* const getBody();
+	const Body* const getBody() const;
 	int setBody(const Body &value);
-	const unsigned int getSize();
+	const unsigned int getSize() const;
 	virtual void encode(unsigned char *bytes);
 	virtual void decode(const unsigned char *bytes);
 	Receive_1_0 &operator=(const Receive_1_0 &value);

--- a/GUI/templates/Common/include/InternalEvents/Receive_1_1.h
+++ b/GUI/templates/Common/include/InternalEvents/Receive_1_1.h
@@ -51,13 +51,13 @@ public:
 			class DllExport SourceID
 			{
 			public:
-				jUnsignedInteger getComponentID();
+				jUnsignedInteger getComponentID() const;
 				int setComponentID(jUnsignedInteger value);
-				jUnsignedInteger getNodeID();
+				jUnsignedInteger getNodeID() const;
 				int setNodeID(jUnsignedInteger value);
-				jUnsignedInteger getSubsystemID();
+				jUnsignedInteger getSubsystemID() const;
 				int setSubsystemID(jUnsignedInteger value);
-				const unsigned int getSize();
+				const unsigned int getSize() const;
 				virtual void encode(unsigned char *bytes);
 				virtual void decode(const unsigned char *bytes);
 				SourceID &operator=(const SourceID &value);
@@ -76,7 +76,7 @@ public:
 				const jUnsignedInteger getLength() const;
 				const unsigned char *getData() const;
 				int set(const jUnsignedInteger &length, const unsigned char *data);
-				const unsigned int getSize();
+				const unsigned int getSize() const;
 				virtual void encode(unsigned char *bytes);
 				virtual void decode(const unsigned char *bytes);
 				MessagePayload &operator=(const MessagePayload &value);
@@ -92,10 +92,12 @@ public:
 			};
 		
 			SourceID* const getSourceID();
+			const SourceID* const getSourceID() const;
 			int setSourceID(const SourceID &value);
 			MessagePayload* const getMessagePayload();
+			const MessagePayload* const getMessagePayload() const;
 			int setMessagePayload(const MessagePayload &value);
-			const unsigned int getSize();
+			const unsigned int getSize() const;
 			virtual void encode(unsigned char *bytes);
 			virtual void decode(const unsigned char *bytes);
 			ReceiveRec &operator=(const ReceiveRec &value);
@@ -111,8 +113,9 @@ public:
 		};
 	
 		ReceiveRec* const getReceiveRec();
+		const ReceiveRec* const getReceiveRec() const;
 		int setReceiveRec(const ReceiveRec &value);
-		const unsigned int getSize();
+		const unsigned int getSize() const;
 		virtual void encode(unsigned char *bytes);
 		virtual void decode(const unsigned char *bytes);
 		Body &operator=(const Body &value);
@@ -127,8 +130,9 @@ public:
 	};
 
 	Body* const getBody();
+	const Body* const getBody() const;
 	int setBody(const Body &value);
-	const unsigned int getSize();
+	const unsigned int getSize() const;
 	virtual void encode(unsigned char *bytes);
 	virtual void decode(const unsigned char *bytes);
 	Receive_1_1 &operator=(const Receive_1_1 &value);

--- a/GUI/templates/Common/include/InternalEvents/Send_1_0.h
+++ b/GUI/templates/Common/include/InternalEvents/Send_1_0.h
@@ -55,7 +55,7 @@ public:
 				const jUnsignedInteger getLength() const;
 				const unsigned char *getData() const;
 				int set(const jUnsignedInteger &length, const unsigned char *data);
-				const unsigned int getSize();
+				const unsigned int getSize() const;
 				virtual void encode(unsigned char *bytes);
 				virtual void decode(const unsigned char *bytes);
 				MessagePayload &operator=(const MessagePayload &value);
@@ -70,28 +70,29 @@ public:
 				unsigned char *m_Data;
 			};
 		
-			jUnsignedByte getPresenceVector();
+			jUnsignedByte getPresenceVector() const;
 			bool checkPresenceVector(unsigned int index) const;
-			jUnsignedShortInteger getDestSubsystemID();
+			jUnsignedShortInteger getDestSubsystemID() const;
 			int setDestSubsystemID(jUnsignedShortInteger value);
-			jUnsignedByte getDestNodeID();
+			jUnsignedByte getDestNodeID() const;
 			int setDestNodeID(jUnsignedByte value);
-			jUnsignedByte getDestComponentID();
+			jUnsignedByte getDestComponentID() const;
 			int setDestComponentID(jUnsignedByte value);
 			bool isSrcSubsystemIDValid() const;
-			jUnsignedShortInteger getSrcSubsystemID();
+			jUnsignedShortInteger getSrcSubsystemID() const;
 			int setSrcSubsystemID(jUnsignedShortInteger value);
 			bool isSrcNodeIDValid() const;
-			jUnsignedByte getSrcNodeID();
+			jUnsignedByte getSrcNodeID() const;
 			int setSrcNodeID(jUnsignedByte value);
-			jUnsignedByte getSrcComponentID();
+			jUnsignedByte getSrcComponentID() const;
 			int setSrcComponentID(jUnsignedByte value);
 			bool isPriorityValid() const;
-			jUnsignedByte getPriority();
+			jUnsignedByte getPriority() const;
 			int setPriority(jUnsignedByte value);
 			MessagePayload* const getMessagePayload();
+			const MessagePayload* const getMessagePayload() const;
 			int setMessagePayload(const MessagePayload &value);
-			const unsigned int getSize();
+			const unsigned int getSize() const;
 			virtual void encode(unsigned char *bytes);
 			virtual void decode(const unsigned char *bytes);
 			SendRec &operator=(const SendRec &value);
@@ -116,8 +117,9 @@ public:
 		};
 	
 		SendRec* const getSendRec();
+		const SendRec* const getSendRec() const;
 		int setSendRec(const SendRec &value);
-		const unsigned int getSize();
+		const unsigned int getSize() const;
 		virtual void encode(unsigned char *bytes);
 		virtual void decode(const unsigned char *bytes);
 		Body &operator=(const Body &value);
@@ -132,8 +134,9 @@ public:
 	};
 
 	Body* const getBody();
+	const Body* const getBody() const;
 	int setBody(const Body &value);
-	const unsigned int getSize();
+	const unsigned int getSize() const;
 	virtual void encode(unsigned char *bytes);
 	virtual void decode(const unsigned char *bytes);
 	Send_1_0 &operator=(const Send_1_0 &value);

--- a/GUI/templates/Common/include/InternalEvents/Send_1_1.h
+++ b/GUI/templates/Common/include/InternalEvents/Send_1_1.h
@@ -51,13 +51,13 @@ public:
 			class DllExport DestinationID
 			{
 			public:
-				jUnsignedInteger getComponentID();
+				jUnsignedInteger getComponentID() const;
 				int setComponentID(jUnsignedInteger value);
-				jUnsignedInteger getNodeID();
+				jUnsignedInteger getNodeID() const;
 				int setNodeID(jUnsignedInteger value);
-				jUnsignedInteger getSubsystemID();
+				jUnsignedInteger getSubsystemID() const;
 				int setSubsystemID(jUnsignedInteger value);
-				const unsigned int getSize();
+				const unsigned int getSize() const;
 				virtual void encode(unsigned char *bytes);
 				virtual void decode(const unsigned char *bytes);
 				DestinationID &operator=(const DestinationID &value);
@@ -73,13 +73,13 @@ public:
 			class DllExport SourceID
 			{
 			public:
-				jUnsignedInteger getComponentID();
+				jUnsignedInteger getComponentID() const;
 				int setComponentID(jUnsignedInteger value);
-				jUnsignedInteger getNodeID();
+				jUnsignedInteger getNodeID() const;
 				int setNodeID(jUnsignedInteger value);
-				jUnsignedInteger getSubsystemID();
+				jUnsignedInteger getSubsystemID() const;
 				int setSubsystemID(jUnsignedInteger value);
-				const unsigned int getSize();
+				const unsigned int getSize() const;
 				virtual void encode(unsigned char *bytes);
 				virtual void decode(const unsigned char *bytes);
 				SourceID &operator=(const SourceID &value);
@@ -98,7 +98,7 @@ public:
 				const jUnsignedInteger getLength() const;
 				const unsigned char *getData() const;
 				int set(const jUnsignedInteger &length, const unsigned char *data);
-				const unsigned int getSize();
+				const unsigned int getSize() const;
 				virtual void encode(unsigned char *bytes);
 				virtual void decode(const unsigned char *bytes);
 				MessagePayload &operator=(const MessagePayload &value);
@@ -113,21 +113,24 @@ public:
 				unsigned char *m_Data;
 			};
 		
-			jUnsignedByte getPresenceVector();
+			jUnsignedByte getPresenceVector() const;
 			bool checkPresenceVector(unsigned int index) const;
-			jUnsignedByte getReliableDelivery();
+			jUnsignedByte getReliableDelivery() const;
 			int setReliableDelivery(jUnsignedByte value);
 			DestinationID* const getDestinationID();
+			const DestinationID* const getDestinationID() const;
 			int setDestinationID(const DestinationID &value);
 			bool isSourceIDValid() const;
 			SourceID* const getSourceID();
+			const SourceID* const getSourceID() const;
 			int setSourceID(const SourceID &value);
 			bool isPriorityValid() const;
-			jUnsignedByte getPriority();
+			jUnsignedByte getPriority() const;
 			int setPriority(jUnsignedByte value);
 			MessagePayload* const getMessagePayload();
+			const MessagePayload* const getMessagePayload() const;
 			int setMessagePayload(const MessagePayload &value);
-			const unsigned int getSize();
+			const unsigned int getSize() const;
 			virtual void encode(unsigned char *bytes);
 			virtual void decode(const unsigned char *bytes);
 			SendRec &operator=(const SendRec &value);
@@ -149,8 +152,9 @@ public:
 		};
 	
 		SendRec* const getSendRec();
+		const SendRec* const getSendRec() const;
 		int setSendRec(const SendRec &value);
-		const unsigned int getSize();
+		const unsigned int getSize() const;
 		virtual void encode(unsigned char *bytes);
 		virtual void decode(const unsigned char *bytes);
 		Body &operator=(const Body &value);
@@ -165,8 +169,9 @@ public:
 	};
 
 	Body* const getBody();
+	const Body* const getBody() const;
 	int setBody(const Body &value);
-	const unsigned int getSize();
+	const unsigned int getSize() const;
 	virtual void encode(unsigned char *bytes);
 	virtual void decode(const unsigned char *bytes);
 	Send_1_1 &operator=(const Send_1_1 &value);

--- a/GUI/templates/Common/include/Messages/Message.h
+++ b/GUI/templates/Common/include/Messages/Message.h
@@ -41,10 +41,10 @@ namespace JTS
 class Message
 {
 public:
-    virtual ~Message(){};
-	virtual unsigned int getID()=0;
-	virtual bool isCommand() { return m_IsCommand; };
-	virtual const unsigned int getSize()=0;
+	virtual ~Message(){};
+	virtual unsigned int getID() const=0;
+	virtual bool isCommand() const { return m_IsCommand; };
+	virtual const unsigned int getSize() const=0;
 	virtual void encode(unsigned char *bytes)=0;
 	virtual void decode(const unsigned char *bytes)=0;
 	

--- a/GUI/templates/Common/include/Service.h
+++ b/GUI/templates/Common/include/Service.h
@@ -54,14 +54,30 @@ namespace JTS
 class DllExport Service : public EventReceiver
 {
 public:
-	Service();
-  	virtual ~Service();
+	Service(const std::string& urn = "Unknown", const jUnsignedByte& majorVersion = 0, const jUnsignedByte& minorVersion = 0);
+	virtual ~Service();
 
 	virtual bool processTransitions(JTS::InternalEvent* ie) = 0;
 	virtual bool defaultTransitions(JTS::InternalEvent* ie) = 0;
 
+	/**
+	 * 
+	 * @return Get the Service URI
+	 */
 	const std::string getURN() const;
-	
+  
+	/**
+	 * 
+	 * @return Major version number for the service
+	 */
+	const jUnsignedByte getMajorVersion() const;
+  
+	/**
+	 * 
+	 * @return Minor version number for the service
+	 */
+	const jUnsignedByte getMinorVersion() const;
+  
 	const std::set<jUnsignedShortInteger> &getInputMessageList() const;
 	const std::set<jUnsignedShortInteger> &getOutputMessageList() const;
 
@@ -72,6 +88,8 @@ protected:
 	std::set<jUnsignedShortInteger> m_OutputMessageList;
 	
 	std::string m_URN;
+	const jUnsignedByte m_majorVersion;
+	const jUnsignedByte m_minorVersion;
 	DeVivo::Junior::JrMutex mutex;
 };
 

--- a/GUI/templates/Common/include/Transport/Archive.h
+++ b/GUI/templates/Common/include/Transport/Archive.h
@@ -91,7 +91,7 @@ public:
         setData( temp.getArchive(), temp.getArchiveLength() );
     }
 
-    template<typename T> T swapBytes(T value)
+    template<typename T> T swapBytes(T value) const
     {
         if ((sizeof(T)!=2) && (sizeof(T)!=4)) return value;
         char temp[sizeof(T)];
@@ -182,7 +182,7 @@ public:
     void append(const char* buffer, unsigned int length);
 
     // We can't use a template to access a string directly
-    void getValueAt(int index, std::string& value)
+    void getValueAt(int index, std::string& value) const
     {
         int size = *((int*)(data+index));
         value.assign( data+index+sizeof(int), size);
@@ -190,7 +190,7 @@ public:
 
     // templated function to access an individual piece of the archive
     // based on some index from the front.
-    template<class T> void getValueAt(int index, T& value)
+    template<class T> void getValueAt(int index, T& value) const
     {
         memcpy(&value,(data+index),sizeof(value));
         bool isBigHost = (htons(256) == 256);
@@ -223,7 +223,7 @@ public:
 
     // Clear the archive completely
     void clear() {data_length = 0;}
-    bool empty() {return (data_length==0);}
+    bool empty() const {return (data_length==0);}
 
     // Set the packing mode (little versus big endian)
     enum PackMode { LittleEndian, BigEndian };
@@ -231,11 +231,12 @@ public:
     enum PackMode getPackMode() { return pack_mode; }
 
     // Access the raw data for message passing
-    unsigned int getArchiveLength() { return data_length; }
+    unsigned int getArchiveLength() const { return data_length; }
     char*          getArchive()       { return data; }
+    const char*          getArchive()  const  { return data; }
 
     // Debugging
-    void printArchive(int size);
+    void printArchive(int size) const;
 
 protected:
 
@@ -249,7 +250,7 @@ protected:
 
 };
 
-inline void Archive::printArchive(int size)
+inline void Archive::printArchive(int size) const
 {
     // get the stream from the logger
     std::ostream& out = Logger::get()->getStream(Logger::full);

--- a/GUI/templates/Common/include/Transport/JausAddress.h
+++ b/GUI/templates/Common/include/Transport/JausAddress.h
@@ -35,6 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "Address.h"
 #include "Transport/OS.h"
+#include <ostream>
 
 class DllExport JausAddress : public Address
 {
@@ -44,20 +45,48 @@ public:
 	JausAddress(jUnsignedInteger value);
 	virtual ~JausAddress();
 	
-	virtual jUnsignedShortInteger getSubsystemID();
+	virtual jUnsignedShortInteger getSubsystemID() const;
 	virtual int setSubsystemID(jUnsignedShortInteger value);
-	virtual jUnsignedByte getNodeID();
+	virtual jUnsignedByte getNodeID() const;
 	virtual int setNodeID(jUnsignedByte value);
-	virtual jUnsignedByte getComponentID();
+	virtual jUnsignedByte getComponentID() const;
 	virtual int setComponentID(jUnsignedByte value);
-	virtual jUnsignedInteger get();
+	virtual jUnsignedInteger get() const;
 
-	virtual bool isLocalSubsystem(jUnsignedShortInteger sID);
-	virtual bool isLocalSubsystem(JausAddress address);
-	virtual bool isLocalNode(jUnsignedShortInteger sID, jUnsignedByte nID);
-	virtual bool isLocalNode(JausAddress address); 
-	virtual bool isLocalComponent(jUnsignedShortInteger sID, jUnsignedByte nID, jUnsignedByte cID);
-	virtual bool isLocalComponent(JausAddress address);
+	virtual bool isLocalSubsystem(jUnsignedShortInteger sID) const;
+	virtual bool isLocalSubsystem(const JausAddress& address) const;
+	virtual bool isLocalNode(jUnsignedShortInteger sID, jUnsignedByte nID) const;
+	virtual bool isLocalNode(const JausAddress& address) const; 
+	virtual bool isLocalComponent(jUnsignedShortInteger sID, jUnsignedByte nID, jUnsignedByte cID) const;
+	virtual bool isLocalComponent(const JausAddress& address) const;
+
+	bool operator==(const JausAddress &value) const;
+	bool operator!=(const JausAddress &value) const;
+  
+	/**
+	 * Less than comparison.
+	 * @param rhs
+	 * @return Compare subsystems first, then nodes, then components
+	 */
+  	bool operator<(const JausAddress& rhs) const;
+  
+	/**
+	 * Greater than comparison.
+	 * @param rhs
+	 * @return Compare subsystems first, then nodes, then components
+	 */
+	inline bool operator>(const JausAddress& rhs) const
+	{
+		return rhs < *this;
+	}
+  
+	friend std::ostream& operator<<(std::ostream& os, const JausAddress& obj)
+	{
+		os << obj.getSubsystemID() << "."
+		   << (uint16_t) obj.getNodeID() << "."
+		   << (uint16_t) obj.getComponentID();
+		return os;
+	}
 };
 
 

--- a/GUI/templates/Common/include/Transport/JrMessage.h
+++ b/GUI/templates/Common/include/Transport/JrMessage.h
@@ -63,17 +63,17 @@ public:
     //
     // Functions to get/set the message code
     //
-    MessageCode getMessageCode(){return _code;}
+    MessageCode getMessageCode() const {return _code;}
     void setMessageCode(MessageCode code){_code = code;}
 
     //
     // Functions to set the source and destination numeric id for the message
     //
     void setSourceId(JAUS_ID source){_source=source;}
-    JAUS_ID getSourceId(){return _source;}
+    JAUS_ID getSourceId() const {return _source;}
 
     void setDestinationId(JAUS_ID destination){_destination=destination;}
-    JAUS_ID getDestinationId(){return _destination;}
+    JAUS_ID getDestinationId() const {return _destination;}
 
     //
     // Functions for priority handling.  Note that AS5669A
@@ -82,9 +82,9 @@ public:
 	// to map one to the other.
     //
     void setPriority(unsigned char prio){_priority=prio;}
-    unsigned char getPriority(){return _priority;}
+    unsigned char getPriority() const {return _priority;}
 	void setScaledPriority(unsigned char prio){_priority = (3*prio)+3;}
-	unsigned char getScaledPriority()
+	unsigned char getScaledPriority() const
 	{
 		if (_priority == 15) return 3;
 		return ((_priority-3)/3);
@@ -94,33 +94,33 @@ public:
     // Functions for ack/nak
     //
     void setAckNakFlag(char flag){_acknak=flag;}
-    char getAckNakFlag(){return _acknak;}
+    char getAckNakFlag() const {return _acknak;}
 
     //
     // Functions for service connection
     //
     void setServiceConnection(char flag){_service_connection = flag;}
-    char getServiceConnection(){return _service_connection;}
+    char getServiceConnection() const {return _service_connection;}
 
     //
     // Functions for experimental bit
     //
     void setExperimental(char flag){_experimental = flag;}
-    char getExperimental(){return _experimental;}
+    char getExperimental() const {return _experimental;}
 
     //
     // Functions for broadcast flag
     //
     void setBroadcast(char flag){_bcast = flag;}
-    char getBroadcast(){return _bcast;}
+    char getBroadcast() const {return _bcast;}
 
     //
     // Functions for data control (large message handling)
     //
 	typedef enum {None, FirstMsg, MiddleMsg, MiddleResentMsg, LastMsg} DataControlFlag;
     void setDataControlFlag(DataControlFlag flag){_control=flag;}
-    DataControlFlag getDataControlFlag(){return _control;}
-	char getDataControlFlagAsChar(MsgVersion version);
+    DataControlFlag getDataControlFlag() const {return _control;}
+	char getDataControlFlagAsChar(MsgVersion version) const;
 	void setDataControlFlagAsChar( char flag, MsgVersion version );
 
     //
@@ -135,11 +135,12 @@ public:
     void setPayload(unsigned int size, const char* data);
     void getPayload(unsigned int& size, char*& data);
     Archive& getPayload(){return _payload;}
+    const Archive& getPayload() const {return _payload;}
 
     //
     // Returns the packed length of data (without headers)
     //
-    unsigned short getDataLength();
+    unsigned short getDataLength() const;
 
 protected:
 
@@ -157,7 +158,7 @@ protected:
 
 };
 
-inline unsigned short Message::getDataLength()
+inline unsigned short Message::getDataLength() const
 {
     // Return the length of the payload
     return _payload.getArchiveLength();
@@ -176,7 +177,7 @@ inline void Message::getPayload(unsigned int& size, char*& data)
     data = _payload.getArchive();
 }
 
-inline char Message::getDataControlFlagAsChar(MsgVersion version)
+inline char Message::getDataControlFlagAsChar(MsgVersion version) const
 {
 	// Note the change in values for 5669 versus 5669A
 	if (_control == None) return 0;

--- a/GUI/templates/Common/include/Transport/Transport.h
+++ b/GUI/templates/Common/include/Transport/Transport.h
@@ -61,16 +61,16 @@ public:
     virtual TransportError initialize(ConfigData& config) = 0;
 
     // Debugging
-    std::string enumToString( TransportError code );
+    std::string enumToString( TransportError code ) const;
     
-    std::string getName(){ return my_name;}
+    std::string getName() const { return my_name;}
     
 protected:
     std::string     my_name;
     
 };
 
-inline std::string Transport::enumToString( TransportError code )
+inline std::string Transport::enumToString( TransportError code ) const
 {
     switch (code)
     {

--- a/GUI/templates/Common/include/Transport/Types.h
+++ b/GUI/templates/Common/include/Transport/Types.h
@@ -115,7 +115,7 @@ class JAUS_ID
         if (val != in.val) return true;
         return false;
     }
-    bool containsWildcards()
+    bool containsWildcards() const
     {
         // More allowance for AEODRS weirdness...
         if ((getByte(val, 2) == 0xFF) && (getByte(val, 3) == 0xFF)) return true;

--- a/GUI/templates/Common/include/jFixedLengthString.h
+++ b/GUI/templates/Common/include/jFixedLengthString.h
@@ -47,7 +47,7 @@ public:
 	jFixedLengthString(const jFixedLengthString &str);
 	virtual ~jFixedLengthString();
 	void setSize(unsigned int size);
-	unsigned int length();
+	unsigned int length() const;
 	const char* c_str() const;
 	jFixedLengthString &operator=(const char* value);
 	jFixedLengthString &operator=(const std::string &value);

--- a/GUI/templates/Common/src/InternalEvents/Receive_1_0.cpp
+++ b/GUI/templates/Common/src/InternalEvents/Receive_1_0.cpp
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace JTS
 {
 
-jUnsignedShortInteger Receive_1_0::Body::ReceiveRec::getSrcSubsystemID()
+jUnsignedShortInteger Receive_1_0::Body::ReceiveRec::getSrcSubsystemID() const
 {
 	return m_SrcSubsystemID;
 }
@@ -46,7 +46,7 @@ int Receive_1_0::Body::ReceiveRec::setSrcSubsystemID(jUnsignedShortInteger value
 	return 0;
 }
 
-jUnsignedByte Receive_1_0::Body::ReceiveRec::getSrcNodeID()
+jUnsignedByte Receive_1_0::Body::ReceiveRec::getSrcNodeID() const
 {
 	return m_SrcNodeID;
 }
@@ -57,7 +57,7 @@ int Receive_1_0::Body::ReceiveRec::setSrcNodeID(jUnsignedByte value)
 	return 0;
 }
 
-jUnsignedByte Receive_1_0::Body::ReceiveRec::getSrcComponentID()
+jUnsignedByte Receive_1_0::Body::ReceiveRec::getSrcComponentID() const
 {
 	return m_SrcComponentID;
 }
@@ -102,7 +102,7 @@ int Receive_1_0::Body::ReceiveRec::MessagePayload::set(const jUnsignedInteger &l
  * 
  * @return
  */
-const unsigned int Receive_1_0::Body::ReceiveRec::MessagePayload::getSize()
+const unsigned int Receive_1_0::Body::ReceiveRec::MessagePayload::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -257,6 +257,11 @@ Receive_1_0::Body::ReceiveRec::MessagePayload* const Receive_1_0::Body::ReceiveR
 	return &m_MessagePayload;
 }
 
+const Receive_1_0::Body::ReceiveRec::MessagePayload* const Receive_1_0::Body::ReceiveRec::getMessagePayload() const
+{
+	return &m_MessagePayload;
+}
+
 int Receive_1_0::Body::ReceiveRec::setMessagePayload(const MessagePayload &value)
 {
 	m_MessagePayload = value;
@@ -271,7 +276,7 @@ int Receive_1_0::Body::ReceiveRec::setMessagePayload(const MessagePayload &value
  * 
  * @return
  */
-const unsigned int Receive_1_0::Body::ReceiveRec::getSize()
+const unsigned int Receive_1_0::Body::ReceiveRec::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -427,6 +432,11 @@ Receive_1_0::Body::ReceiveRec* const Receive_1_0::Body::getReceiveRec()
 	return &m_ReceiveRec;
 }
 
+const Receive_1_0::Body::ReceiveRec* const Receive_1_0::Body::getReceiveRec() const
+{
+	return &m_ReceiveRec;
+}
+
 int Receive_1_0::Body::setReceiveRec(const ReceiveRec &value)
 {
 	m_ReceiveRec = value;
@@ -441,7 +451,7 @@ int Receive_1_0::Body::setReceiveRec(const ReceiveRec &value)
  * 
  * @return
  */
-const unsigned int Receive_1_0::Body::getSize()
+const unsigned int Receive_1_0::Body::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -528,6 +538,11 @@ Receive_1_0::Body* const Receive_1_0::getBody()
 	return &m_Body;
 }
 
+const Receive_1_0::Body* const Receive_1_0::getBody() const
+{
+	return &m_Body;
+}
+
 int Receive_1_0::setBody(const Body &value)
 {
 	m_Body = value;
@@ -542,7 +557,7 @@ int Receive_1_0::setBody(const Body &value)
  * 
  * @return
  */
-const unsigned int Receive_1_0::getSize()
+const unsigned int Receive_1_0::getSize() const
 {
 	unsigned int size = 0;
 	

--- a/GUI/templates/Common/src/InternalEvents/Receive_1_1.cpp
+++ b/GUI/templates/Common/src/InternalEvents/Receive_1_1.cpp
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace JTS
 {
 
-jUnsignedInteger Receive_1_1::Body::ReceiveRec::SourceID::getComponentID()
+jUnsignedInteger Receive_1_1::Body::ReceiveRec::SourceID::getComponentID() const
 {
 	std::bitset<sizeof(jUnsignedInteger) * 8> bfbs((int) m_SubFields);
 	std::bitset<8> sfbs;
@@ -68,7 +68,7 @@ int Receive_1_1::Body::ReceiveRec::SourceID::setComponentID(jUnsignedInteger val
 	return 1;
 }
 
-jUnsignedInteger Receive_1_1::Body::ReceiveRec::SourceID::getNodeID()
+jUnsignedInteger Receive_1_1::Body::ReceiveRec::SourceID::getNodeID() const
 {
 	std::bitset<sizeof(jUnsignedInteger) * 8> bfbs((int) m_SubFields);
 	std::bitset<8> sfbs;
@@ -101,7 +101,7 @@ int Receive_1_1::Body::ReceiveRec::SourceID::setNodeID(jUnsignedInteger value)
 	return 1;
 }
 
-jUnsignedInteger Receive_1_1::Body::ReceiveRec::SourceID::getSubsystemID()
+jUnsignedInteger Receive_1_1::Body::ReceiveRec::SourceID::getSubsystemID() const
 {
 	std::bitset<sizeof(jUnsignedInteger) * 8> bfbs((int) m_SubFields);
 	std::bitset<16> sfbs;
@@ -142,7 +142,7 @@ int Receive_1_1::Body::ReceiveRec::SourceID::setSubsystemID(jUnsignedInteger val
  * 
  * @return
  */
-const unsigned int Receive_1_1::Body::ReceiveRec::SourceID::getSize()
+const unsigned int Receive_1_1::Body::ReceiveRec::SourceID::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -223,6 +223,11 @@ Receive_1_1::Body::ReceiveRec::SourceID* const Receive_1_1::Body::ReceiveRec::ge
 	return &m_SourceID;
 }
 
+const Receive_1_1::Body::ReceiveRec::SourceID* const Receive_1_1::Body::ReceiveRec::getSourceID() const
+{
+	return &m_SourceID;
+}
+
 int Receive_1_1::Body::ReceiveRec::setSourceID(const SourceID &value)
 {
 	m_SourceID = value;
@@ -263,7 +268,7 @@ int Receive_1_1::Body::ReceiveRec::MessagePayload::set(const jUnsignedInteger &l
  * 
  * @return
  */
-const unsigned int Receive_1_1::Body::ReceiveRec::MessagePayload::getSize()
+const unsigned int Receive_1_1::Body::ReceiveRec::MessagePayload::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -418,6 +423,11 @@ Receive_1_1::Body::ReceiveRec::MessagePayload* const Receive_1_1::Body::ReceiveR
 	return &m_MessagePayload;
 }
 
+const Receive_1_1::Body::ReceiveRec::MessagePayload* const Receive_1_1::Body::ReceiveRec::getMessagePayload() const
+{
+	return &m_MessagePayload;
+}
+
 int Receive_1_1::Body::ReceiveRec::setMessagePayload(const MessagePayload &value)
 {
 	m_MessagePayload = value;
@@ -432,7 +442,7 @@ int Receive_1_1::Body::ReceiveRec::setMessagePayload(const MessagePayload &value
  * 
  * @return
  */
-const unsigned int Receive_1_1::Body::ReceiveRec::getSize()
+const unsigned int Receive_1_1::Body::ReceiveRec::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -536,6 +546,11 @@ Receive_1_1::Body::ReceiveRec* const Receive_1_1::Body::getReceiveRec()
 	return &m_ReceiveRec;
 }
 
+const Receive_1_1::Body::ReceiveRec* const Receive_1_1::Body::getReceiveRec() const
+{
+	return &m_ReceiveRec;
+}
+
 int Receive_1_1::Body::setReceiveRec(const ReceiveRec &value)
 {
 	m_ReceiveRec = value;
@@ -550,7 +565,7 @@ int Receive_1_1::Body::setReceiveRec(const ReceiveRec &value)
  * 
  * @return
  */
-const unsigned int Receive_1_1::Body::getSize()
+const unsigned int Receive_1_1::Body::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -637,6 +652,11 @@ Receive_1_1::Body* const Receive_1_1::getBody()
 	return &m_Body;
 }
 
+const Receive_1_1::Body* const Receive_1_1::getBody() const
+{
+	return &m_Body;
+}
+
 int Receive_1_1::setBody(const Body &value)
 {
 	m_Body = value;
@@ -651,7 +671,7 @@ int Receive_1_1::setBody(const Body &value)
  * 
  * @return
  */
-const unsigned int Receive_1_1::getSize()
+const unsigned int Receive_1_1::getSize() const
 {
 	unsigned int size = 0;
 	

--- a/GUI/templates/Common/src/InternalEvents/Send_1_0.cpp
+++ b/GUI/templates/Common/src/InternalEvents/Send_1_0.cpp
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace JTS
 {
 
-jUnsignedByte Send_1_0::Body::SendRec::getPresenceVector()
+jUnsignedByte Send_1_0::Body::SendRec::getPresenceVector() const
 {
 	return m_PresenceVector;
 }
@@ -56,7 +56,7 @@ bool Send_1_0::Body::SendRec::checkPresenceVector(unsigned int index) const
 	return (pvBitSet[index] == 1);
 }
 
-jUnsignedShortInteger Send_1_0::Body::SendRec::getDestSubsystemID()
+jUnsignedShortInteger Send_1_0::Body::SendRec::getDestSubsystemID() const
 {
 	return m_DestSubsystemID;
 }
@@ -67,7 +67,7 @@ int Send_1_0::Body::SendRec::setDestSubsystemID(jUnsignedShortInteger value)
 	return 0;
 }
 
-jUnsignedByte Send_1_0::Body::SendRec::getDestNodeID()
+jUnsignedByte Send_1_0::Body::SendRec::getDestNodeID() const
 {
 	return m_DestNodeID;
 }
@@ -78,7 +78,7 @@ int Send_1_0::Body::SendRec::setDestNodeID(jUnsignedByte value)
 	return 0;
 }
 
-jUnsignedByte Send_1_0::Body::SendRec::getDestComponentID()
+jUnsignedByte Send_1_0::Body::SendRec::getDestComponentID() const
 {
 	return m_DestComponentID;
 }
@@ -98,7 +98,7 @@ bool Send_1_0::Body::SendRec::isSrcSubsystemIDValid() const
 	return false;
 }
 
-jUnsignedShortInteger Send_1_0::Body::SendRec::getSrcSubsystemID()
+jUnsignedShortInteger Send_1_0::Body::SendRec::getSrcSubsystemID() const
 {
 	return m_SrcSubsystemID;
 }
@@ -119,7 +119,7 @@ bool Send_1_0::Body::SendRec::isSrcNodeIDValid() const
 	return false;
 }
 
-jUnsignedByte Send_1_0::Body::SendRec::getSrcNodeID()
+jUnsignedByte Send_1_0::Body::SendRec::getSrcNodeID() const
 {
 	return m_SrcNodeID;
 }
@@ -131,7 +131,7 @@ int Send_1_0::Body::SendRec::setSrcNodeID(jUnsignedByte value)
 	return 0;
 }
 
-jUnsignedByte Send_1_0::Body::SendRec::getSrcComponentID()
+jUnsignedByte Send_1_0::Body::SendRec::getSrcComponentID() const
 {
 	return m_SrcComponentID;
 }
@@ -151,7 +151,7 @@ bool Send_1_0::Body::SendRec::isPriorityValid() const
 	return false;
 }
 
-jUnsignedByte Send_1_0::Body::SendRec::getPriority()
+jUnsignedByte Send_1_0::Body::SendRec::getPriority() const
 {
 	return m_Priority;
 }
@@ -201,7 +201,7 @@ int Send_1_0::Body::SendRec::MessagePayload::set(const jUnsignedInteger &length,
  * 
  * @return
  */
-const unsigned int Send_1_0::Body::SendRec::MessagePayload::getSize()
+const unsigned int Send_1_0::Body::SendRec::MessagePayload::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -356,6 +356,11 @@ Send_1_0::Body::SendRec::MessagePayload* const Send_1_0::Body::SendRec::getMessa
 	return &m_MessagePayload;
 }
 
+const Send_1_0::Body::SendRec::MessagePayload* const Send_1_0::Body::SendRec::getMessagePayload() const
+{
+	return &m_MessagePayload;
+}
+
 int Send_1_0::Body::SendRec::setMessagePayload(const MessagePayload &value)
 {
 	m_MessagePayload = value;
@@ -370,7 +375,7 @@ int Send_1_0::Body::SendRec::setMessagePayload(const MessagePayload &value)
  * 
  * @return
  */
-const unsigned int Send_1_0::Body::SendRec::getSize()
+const unsigned int Send_1_0::Body::SendRec::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -660,6 +665,11 @@ Send_1_0::Body::SendRec* const Send_1_0::Body::getSendRec()
 	return &m_SendRec;
 }
 
+const Send_1_0::Body::SendRec* const Send_1_0::Body::getSendRec() const
+{
+	return &m_SendRec;
+}
+
 int Send_1_0::Body::setSendRec(const SendRec &value)
 {
 	m_SendRec = value;
@@ -674,7 +684,7 @@ int Send_1_0::Body::setSendRec(const SendRec &value)
  * 
  * @return
  */
-const unsigned int Send_1_0::Body::getSize()
+const unsigned int Send_1_0::Body::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -761,6 +771,11 @@ Send_1_0::Body* const Send_1_0::getBody()
 	return &m_Body;
 }
 
+const Send_1_0::Body* const Send_1_0::getBody() const
+{
+	return &m_Body;
+}
+
 int Send_1_0::setBody(const Body &value)
 {
 	m_Body = value;
@@ -775,7 +790,7 @@ int Send_1_0::setBody(const Body &value)
  * 
  * @return
  */
-const unsigned int Send_1_0::getSize()
+const unsigned int Send_1_0::getSize() const
 {
 	unsigned int size = 0;
 	

--- a/GUI/templates/Common/src/InternalEvents/Send_1_1.cpp
+++ b/GUI/templates/Common/src/InternalEvents/Send_1_1.cpp
@@ -35,7 +35,7 @@ POSSIBILITY OF SUCH DAMAGE.
 namespace JTS
 {
 
-jUnsignedByte Send_1_1::Body::SendRec::getPresenceVector()
+jUnsignedByte Send_1_1::Body::SendRec::getPresenceVector() const
 {
 	return m_PresenceVector;
 }
@@ -56,7 +56,7 @@ bool Send_1_1::Body::SendRec::checkPresenceVector(unsigned int index) const
 	return (pvBitSet[index] == 1);
 }
 
-jUnsignedByte Send_1_1::Body::SendRec::getReliableDelivery()
+jUnsignedByte Send_1_1::Body::SendRec::getReliableDelivery() const
 {
 	return m_ReliableDelivery;
 }
@@ -71,7 +71,7 @@ int Send_1_1::Body::SendRec::setReliableDelivery(jUnsignedByte value)
 	return 1;
 }
 
-jUnsignedInteger Send_1_1::Body::SendRec::DestinationID::getComponentID()
+jUnsignedInteger Send_1_1::Body::SendRec::DestinationID::getComponentID() const
 {
 	std::bitset<(int)(sizeof(jUnsignedInteger) * 8)> bfbs((int)m_SubFields);
 	std::bitset<(int)8> sfbs;
@@ -104,7 +104,7 @@ int Send_1_1::Body::SendRec::DestinationID::setComponentID(jUnsignedInteger valu
 	return 1;
 }
 
-jUnsignedInteger Send_1_1::Body::SendRec::DestinationID::getNodeID()
+jUnsignedInteger Send_1_1::Body::SendRec::DestinationID::getNodeID() const
 {
 	std::bitset<(int)(sizeof(jUnsignedInteger) * 8)> bfbs((int) m_SubFields);
 	std::bitset<(int)8> sfbs;
@@ -137,7 +137,7 @@ int Send_1_1::Body::SendRec::DestinationID::setNodeID(jUnsignedInteger value)
 	return 1;
 }
 
-jUnsignedInteger Send_1_1::Body::SendRec::DestinationID::getSubsystemID()
+jUnsignedInteger Send_1_1::Body::SendRec::DestinationID::getSubsystemID() const
 {
 	std::bitset<(int)(sizeof(jUnsignedInteger) * 8)> bfbs((int) m_SubFields);
 	std::bitset<(int)16> sfbs;
@@ -178,7 +178,7 @@ int Send_1_1::Body::SendRec::DestinationID::setSubsystemID(jUnsignedInteger valu
  * 
  * @return
  */
-const unsigned int Send_1_1::Body::SendRec::DestinationID::getSize()
+const unsigned int Send_1_1::Body::SendRec::DestinationID::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -259,13 +259,18 @@ Send_1_1::Body::SendRec::DestinationID* const Send_1_1::Body::SendRec::getDestin
 	return &m_DestinationID;
 }
 
+const Send_1_1::Body::SendRec::DestinationID* const Send_1_1::Body::SendRec::getDestinationID() const
+{
+	return &m_DestinationID;
+}
+
 int Send_1_1::Body::SendRec::setDestinationID(const DestinationID &value)
 {
 	m_DestinationID = value;
 	return 0;
 }
 
-jUnsignedInteger Send_1_1::Body::SendRec::SourceID::getComponentID()
+jUnsignedInteger Send_1_1::Body::SendRec::SourceID::getComponentID() const
 {
 	std::bitset<(int)(sizeof(jUnsignedInteger) * 8)> bfbs((int) m_SubFields);
 	std::bitset<(int)8> sfbs;
@@ -298,7 +303,7 @@ int Send_1_1::Body::SendRec::SourceID::setComponentID(jUnsignedInteger value)
 	return 1;
 }
 
-jUnsignedInteger Send_1_1::Body::SendRec::SourceID::getNodeID()
+jUnsignedInteger Send_1_1::Body::SendRec::SourceID::getNodeID() const
 {
 	std::bitset<(int)(sizeof(jUnsignedInteger) * 8)> bfbs((int) m_SubFields);
 	std::bitset<(int)8> sfbs;
@@ -331,7 +336,7 @@ int Send_1_1::Body::SendRec::SourceID::setNodeID(jUnsignedInteger value)
 	return 1;
 }
 
-jUnsignedInteger Send_1_1::Body::SendRec::SourceID::getSubsystemID()
+jUnsignedInteger Send_1_1::Body::SendRec::SourceID::getSubsystemID() const
 {
 	std::bitset<(int)(sizeof(jUnsignedInteger) * 8)> bfbs((int) m_SubFields);
 	std::bitset<(int)16> sfbs;
@@ -372,7 +377,7 @@ int Send_1_1::Body::SendRec::SourceID::setSubsystemID(jUnsignedInteger value)
  * 
  * @return
  */
-const unsigned int Send_1_1::Body::SendRec::SourceID::getSize()
+const unsigned int Send_1_1::Body::SendRec::SourceID::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -462,6 +467,11 @@ Send_1_1::Body::SendRec::SourceID* const Send_1_1::Body::SendRec::getSourceID()
 	return &m_SourceID;
 }
 
+const Send_1_1::Body::SendRec::SourceID* const Send_1_1::Body::SendRec::getSourceID() const
+{
+	return &m_SourceID;
+}
+
 int Send_1_1::Body::SendRec::setSourceID(const SourceID &value)
 {
 	m_SourceID = value;
@@ -478,7 +488,7 @@ bool Send_1_1::Body::SendRec::isPriorityValid() const
 	return false;
 }
 
-jUnsignedByte Send_1_1::Body::SendRec::getPriority()
+jUnsignedByte Send_1_1::Body::SendRec::getPriority() const
 {
 	return m_Priority;
 }
@@ -528,7 +538,7 @@ int Send_1_1::Body::SendRec::MessagePayload::set(const jUnsignedInteger &length,
  * 
  * @return
  */
-const unsigned int Send_1_1::Body::SendRec::MessagePayload::getSize()
+const unsigned int Send_1_1::Body::SendRec::MessagePayload::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -683,6 +693,11 @@ Send_1_1::Body::SendRec::MessagePayload* const Send_1_1::Body::SendRec::getMessa
 	return &m_MessagePayload;
 }
 
+const Send_1_1::Body::SendRec::MessagePayload* const Send_1_1::Body::SendRec::getMessagePayload() const
+{
+	return &m_MessagePayload;
+}
+
 int Send_1_1::Body::SendRec::setMessagePayload(const MessagePayload &value)
 {
 	m_MessagePayload = value;
@@ -697,7 +712,7 @@ int Send_1_1::Body::SendRec::setMessagePayload(const MessagePayload &value)
  * 
  * @return
  */
-const unsigned int Send_1_1::Body::SendRec::getSize()
+const unsigned int Send_1_1::Body::SendRec::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -901,6 +916,11 @@ Send_1_1::Body::SendRec* const Send_1_1::Body::getSendRec()
 	return &m_SendRec;
 }
 
+const Send_1_1::Body::SendRec* const Send_1_1::Body::getSendRec() const
+{
+	return &m_SendRec;
+}
+
 int Send_1_1::Body::setSendRec(const SendRec &value)
 {
 	m_SendRec = value;
@@ -915,7 +935,7 @@ int Send_1_1::Body::setSendRec(const SendRec &value)
  * 
  * @return
  */
-const unsigned int Send_1_1::Body::getSize()
+const unsigned int Send_1_1::Body::getSize() const
 {
 	unsigned int size = 0;
 	
@@ -1002,6 +1022,11 @@ Send_1_1::Body* const Send_1_1::getBody()
 	return &m_Body;
 }
 
+const Send_1_1::Body* const Send_1_1::getBody() const
+{
+	return &m_Body;
+}
+
 int Send_1_1::setBody(const Body &value)
 {
 	m_Body = value;
@@ -1016,7 +1041,7 @@ int Send_1_1::setBody(const Body &value)
  * 
  * @return
  */
-const unsigned int Send_1_1::getSize()
+const unsigned int Send_1_1::getSize() const
 {
 	unsigned int size = 0;
 	

--- a/GUI/templates/Common/src/Service.cpp
+++ b/GUI/templates/Common/src/Service.cpp
@@ -36,9 +36,11 @@ namespace JTS
 {
 
 //Service::Service(Router *msgRouter)
-Service::Service()
+Service::Service(const std::string& urn, const jUnsignedByte& majorVersion, const jUnsignedByte& minorVersion) 
+  : m_URN(urn)
+  , m_majorVersion(majorVersion)
+  , m_minorVersion(minorVersion)
 {
-	m_URN = "Unknown";
 }
 
 
@@ -49,6 +51,16 @@ Service::~Service()
 const std::string Service::getURN() const
 {
 	return m_URN;
+}
+
+const jUnsignedByte Service::getMajorVersion() const
+{
+	return m_majorVersion;
+}
+
+const jUnsignedByte Service::getMinorVersion() const
+{
+	return m_minorVersion;
 }
 
 const std::set<jUnsignedShortInteger> &Service::getInputMessageList() const

--- a/GUI/templates/Common/src/Transport/JausAddress.cpp
+++ b/GUI/templates/Common/src/Transport/JausAddress.cpp
@@ -32,7 +32,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "Transport/JausAddress.h"
 
-
 JausAddress::JausAddress()
 {
 	address = malloc(sizeof(jUnsignedInteger));
@@ -65,19 +64,18 @@ JausAddress::JausAddress(jUnsignedInteger value)
 	*((jUnsignedInteger*)address) = tempValue;
 }
 
-
 JausAddress::~JausAddress()
 {
 	if (address != NULL) free(address);
 	size = 0;
 }
 
-jUnsignedInteger JausAddress::get()
+jUnsignedInteger JausAddress::get() const
 {
 	return *((jUnsignedInteger*)address);
 }
 
-jUnsignedShortInteger JausAddress::getSubsystemID()
+jUnsignedShortInteger JausAddress::getSubsystemID() const
 {
 	jUnsignedInteger tempValue = *((jUnsignedInteger*)address);
 	return (jUnsignedShortInteger)(tempValue >> 16);
@@ -92,7 +90,7 @@ int JausAddress::setSubsystemID(jUnsignedShortInteger value)
 	return 0;
 }
 
-jUnsignedByte JausAddress::getNodeID()
+jUnsignedByte JausAddress::getNodeID() const
 {
 	jUnsignedInteger tempValue = *((jUnsignedInteger*)address);
 	
@@ -111,7 +109,7 @@ int JausAddress::setNodeID(jUnsignedByte value)
 	return 0;
 }
 
-jUnsignedByte JausAddress::getComponentID()
+jUnsignedByte JausAddress::getComponentID() const
 {
 	jUnsignedInteger tempValue = *((jUnsignedInteger*)address);
 	return (jUnsignedByte)(tempValue & 0x000000FF);
@@ -126,33 +124,63 @@ int JausAddress::setComponentID(jUnsignedByte value)
 	return 0;
 }
 
-bool JausAddress::isLocalSubsystem(jUnsignedShortInteger sID)
+bool JausAddress::isLocalSubsystem(jUnsignedShortInteger sID) const
 {
 	return (getSubsystemID() == sID);
 }
 
-bool JausAddress::isLocalSubsystem(JausAddress address)
+bool JausAddress::isLocalSubsystem(const JausAddress& address) const
 {
 	return (getSubsystemID() == address.getSubsystemID());
 }
 
-bool JausAddress::isLocalNode(jUnsignedShortInteger sID, jUnsignedByte nID)
+bool JausAddress::isLocalNode(jUnsignedShortInteger sID, jUnsignedByte nID) const
 {
 	return (isLocalSubsystem(sID) && (getNodeID() == nID));
 }
 
-bool JausAddress::isLocalNode(JausAddress address)
+bool JausAddress::isLocalNode(const JausAddress& address) const
 {
 	return (isLocalSubsystem(address) && (getNodeID() == address.getNodeID()));
 }
 
-bool JausAddress::isLocalComponent(jUnsignedShortInteger sID, jUnsignedByte nID, jUnsignedByte cID)
+bool JausAddress::isLocalComponent(jUnsignedShortInteger sID, jUnsignedByte nID, jUnsignedByte cID) const
 {
-	return (isLocalNode(sID, nID) && (getComponentID() == cID)); 
+	return (isLocalNode(sID, nID) && (getComponentID() == cID));
 }
 
-bool JausAddress::isLocalComponent(JausAddress address)
+bool JausAddress::isLocalComponent(const JausAddress& address) const
 {
-	return (isLocalNode(address) && (getComponentID() == address.getComponentID())); 
+	return (isLocalNode(address) && (getComponentID() == address.getComponentID()));
+}
+
+bool JausAddress::operator==(const JausAddress &value) const 
+{
+	return (get() == value.get());
+}
+
+bool JausAddress::operator!=(const JausAddress &value) const 
+{
+	return (get() != value.get());
+}
+
+bool JausAddress::operator<(const JausAddress& rhs) const
+{
+	if (getSubsystemID() < rhs.getSubsystemID())
+	{
+		return true;
+	} else if (getSubsystemID() > rhs.getSubsystemID())
+	{
+		return false;
+	} else if (getNodeID() < rhs.getNodeID())
+	{
+		return true;
+	} else if (getNodeID() > rhs.getNodeID())
+	{
+		return false;
+	} else
+	{
+		return (getComponentID() < rhs.getComponentID());
+	}
 }
 

--- a/GUI/templates/Common/src/jFixedLengthString.cpp
+++ b/GUI/templates/Common/src/jFixedLengthString.cpp
@@ -82,7 +82,7 @@ void jFixedLengthString::setSize(unsigned int size)
 	this->data.resize(this->size);
 }
 
-unsigned int jFixedLengthString::length()
+unsigned int jFixedLengthString::length() const
 {
 	return this->size;
 }


### PR DESCRIPTION
Updated JTS Common C++ code to have const getters. All of these
changes should be backwards compatible. When needed, a second
method signature was added to provide bot a const and non-const
version of the method. Most of these cases were when a reference
was being returned.

Two additional modifications:

JausAddress:
  - Updated to have equals, not-equals, less-than, greater-than
    operators.
  - Updated to have an stream operator for output <<().

Service:
  - Updated the constructor to take the URI, major and minor
    versions. These have default values so it should be
    backwards compatible.

Fixes #60.