### PR TITLE
Fix C++ bitfield generation for 64-bit ints

### DIFF
--- a/GUI/src/org/jts/codegenerator/BitFieldGenerator.java
+++ b/GUI/src/org/jts/codegenerator/BitFieldGenerator.java
@@ -334,7 +334,7 @@ public class BitFieldGenerator //extends FieldClass
         {
             code.publicMethods.add(CppCode.createMethodDeclaration(bfType, "get", subFieldName, methodParam, false));
 
-            methodCode.add("std::bitset<sizeof(" + bfType + ") * 8> bfbs((int)m_SubFields);");
+            methodCode.add("std::bitset<sizeof(" + bfType + ") * 8> bfbs(m_SubFields);");
             methodCode.add("std::bitset<" + size +"> sfbs;");
             methodCode.add("int i = 0;");
             methodCode.add("");
@@ -343,7 +343,7 @@ public class BitFieldGenerator //extends FieldClass
             methodCode.add("    sfbs[i++] = bfbs[index];");
             methodCode.add("}");
             methodCode.add("");
-            methodCode.add("return (" + bfType + ")(sfbs.to_ulong());");
+            methodCode.add("return (" + bfType + ")(sfbs.to_ullong());");
             code.methods.addAll(CppCode.createMethodDefinition(bfType, fullClassName + "::get", subFieldName, methodParam, methodCode, false));
         }
         else if(codeType == CodeLines.CodeType.JAVA)
@@ -386,8 +386,8 @@ public class BitFieldGenerator //extends FieldClass
         {
             code.publicMethods.add(CppCode.createMethodDeclaration("int", "set", subFieldName, methodParam, false));
 
-            methodCode.add("std::bitset<sizeof(" + bfType + ") * 8> bfbs((int)m_SubFields);");
-            methodCode.add("std::bitset<" + size + "> sfbs((int)value);");
+            methodCode.add("std::bitset<sizeof(" + bfType + ") * 8> bfbs(m_SubFields);");
+            methodCode.add("std::bitset<" + size + "> sfbs(value);");
             methodCode.add("int i = 0;");
             methodCode.add("");
             methodCode.add("for (int index = " + fromIndex + "; index <= " + toIndex + "; index++)");
@@ -395,7 +395,7 @@ public class BitFieldGenerator //extends FieldClass
             methodCode.add("    bfbs[index] = sfbs[i++];");
             methodCode.add("}");
             methodCode.add("");
-            methodCode.add("m_SubFields = (" + bfType + ")bfbs.to_ulong();");
+            methodCode.add("m_SubFields = (" + bfType + ")bfbs.to_ullong();");
             // Create framework for parent reference
             methodCode.add(CppCode.getParentReferenceSetParentPVLine());
             methodCode.add("return 0;");

--- a/GUI/src/org/jts/codegenerator/support/SconstructGenerator.java
+++ b/GUI/src/org/jts/codegenerator/support/SconstructGenerator.java
@@ -275,7 +275,7 @@ public class SconstructGenerator
 		buf.append("\tenv.Append( CCFLAGS = ['-D__MAC__'] )").append(System.getProperty("line.separator"));		
 		buf.append("elif os.name == 'posix':").append(System.getProperty("line.separator"));
 		buf.append("\tenv.Append( LINKFLAGS = ['-lpthread', '-lrt'] )").append(System.getProperty("line.separator"));
-		buf.append("\tenv.Append( CPPFLAGS = ['-g', '-Wno-write-strings'])").append(System.getProperty("line.separator"));
+		buf.append("\tenv.Append( CPPFLAGS = ['-g', '-Wno-write-strings', '-std=c++11'])").append(System.getProperty("line.separator"));
         buf.append("\textra_libs = ['pthread', 'rt']").append(System.getProperty("line.separator"));
 		buf.append("Export('env')").append(System.getProperty("line.separator"));
 		buf.append(System.getProperty("line.separator"));			


### PR DESCRIPTION
Addresses issue #75 

Removes unnecessary casting, and switches to using to_ullong. That necessitates C++11 support, so a change to the Sconstructor generator was also necessary. 