### PR TITLE
Fix and add support for parsing "JAUS MESSAGE" in VLF

### DIFF
--- a/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/packet-jaus.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/packet-jaus.c
@@ -1264,13 +1264,51 @@ int dissect_variable_length_field(tvbuff_t *tvb, proto_tree *tree, variable_leng
 
 	offset += size;
 
-	data = ep_tvb_memdup(tvb, offset, (int)field_length);
+	proto_item *vlf_item = proto_tree_add_text(
+		tree, tvb, offset, ((int)field_length), "[VLF] %s: (%s)", vlf_ptr->name, vlf_ptr->field_format);
+	proto_tree *vlf_tree = proto_item_add_subtree(vlf_item, ett_jaus_data);
 
-	proto_tree_add_bytes_format(tree, hf_jaus_uint64, tvb, offset, ((int)field_length + size), data, "[VLF] %s: (%s) 0x%hhn",
-		vlf_ptr->name, vlf_ptr->field_format, data);
+	const char *count_type = decode_field_type(cf_ptr->field_type_unsigned);
 
-	data_offset = (offset + (int)field_length);
-	return(0);
+	proto_tree_add_uint64_format(
+		vlf_tree, hf_jaus_uint64, tvb, data_offset, size, -1, "[CF] (%s) min: %d, max: %d, count: %lu",
+		count_type, cf_ptr->min_count, cf_ptr->max_count, field_length);
+
+	if (strcmp(vlf_ptr->field_format, "JAUS MESSAGE") == 0)
+	{
+		message_def_t *m_ptr_sub;
+		bool found_sub_msg = false;
+		unsigned short sub_command = tvb_get_letohs(tvb, offset);
+
+		m_ptr_sub = message_set;
+		while (m_ptr_sub != NULL)
+		{
+			if (m_ptr_sub->message_id == sub_command)
+			{
+				found_sub_msg = true;
+				break;
+			}
+			m_ptr_sub = m_ptr_sub->next;
+		}
+
+		proto_item *sub_item = proto_tree_add_uint_format(
+			vlf_tree, hf_jaus_commandCode, tvb, offset, 2, sub_command,
+			"Command Code: %s (0x%04X)", (found_sub_msg) ? m_ptr_sub->name : "NotFoundInXML", sub_command);
+		offset += 2;
+		proto_tree *sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+		if (found_sub_msg)
+		{
+			data_offset = dissect_message_data(tvb, sub_tree, offset, m_ptr_sub);
+		}
+	}
+	else
+	{
+		data = ep_tvb_memdup(tvb, offset, (int)field_length);
+		proto_tree_add_bytes(vlf_tree, hf_jaus_data, tvb, offset, ((int)field_length), data);
+		data_offset = (offset + (int)field_length);
+	}
+	return (0);
 }
 
 int dissect_variable_format_field(tvbuff_t *tvb, proto_tree *tree, variable_format_field_t *vff_ptr)
@@ -1690,4 +1728,35 @@ int get_ra3_id_from_tvb(tvbuff_t *tvb, int offset, char* jaus_id)
 	const int node = tvb_get_guint8(tvb , offset+2);
 	const int subs = tvb_get_guint8(tvb , offset+3);
 	return sprintf(jaus_id, "%d.%d.%d.%d", subs, node, comp, inst);
+}
+
+char *decode_field_type(char type)
+{
+	static char result[32];
+	switch (type)
+	{
+	case PDT_BYTE:
+		return "byte";
+	case PDT_SHORT_INT:
+		return "short integer";
+	case PDT_INT:
+		return "integer";
+	case PDT_LONG_INT:
+		return "long integer";
+	case PDT_UBYTE:
+		return "unsigned byte";
+	case PDT_USHORT_INT:
+		return "unsigned short integer";
+	case PDT_UINT:
+		return "unsigned integer";
+	case PDT_ULONG_INT:
+		return "unsigned long integer";
+	case PDT_FLOAT:
+		return "float";
+	case PDT_LONG_FLOAT:
+		return "long float";
+	default:
+		sprintf(result, "UNKNOWN(%d)", (int)type);
+		return result;
+	}
 }


### PR DESCRIPTION
Variable length field parsing appears to currently be broken in the Wireshark 3.2 plugin. It results in a malformed packet error. See:

<img width="559" height="189" alt="image" src="https://github.com/user-attachments/assets/4a33dd77-ce7d-4b86-a937-8b8a2990bc42" />


This notably causes an issue with Events. This MR fixes the parsing issue allowing users to see the variable field min/max/count as well as data.

Additionally, if the "field_format" is "JAUS_MESSAGE", it will parse the message and add it to the packet tree.

<img width="561" height="199" alt="image" src="https://github.com/user-attachments/assets/1ebd154f-9501-4dd8-87e8-68d1215e74e3" />

Note, "field_format"s other than "JAUS_MESSAGE" will just display the count field and the raw bytes in the tree. (Which is broken on master).

I tried to make the tree layout consistent with what I saw elsewhere, but I'm definitely open to feedback.