### PR TITLE
Fix parsing of VariableFormatFields

### DIFF
--- a/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/jausxml.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/jausxml.c
@@ -1318,7 +1318,7 @@ void parse_format_enum(xmlNode *fe_node, format_enum_t *format_enum)
 	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"index"))) {
 			format_enum->index = (unsigned char)strtol((char *)get_attr_value(cur_node), NULL, 10);
  	    }
-		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"format_field"))) {
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_format"))) {
 			strncpy(format_enum->field_format, (char *)get_attr_value(cur_node), 15);
  	    }
 	}

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/packet-jaus.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/packet-jaus.c
@@ -1322,17 +1322,9 @@ int dissect_variable_format_field(tvbuff_t *tvb, proto_tree *tree, variable_form
 
 	/* print with enum field_format name else error? with just the data from buffer */
 	const char *count_type = decode_field_type(cf_ptr->field_type_unsigned);
-	char* format_string;
-	if (found_fe)
-	{
-		format_string = fe_ptr->field_format;
-	}
-	else
-	{
-		static char temp[25];
-		sprintf(temp, "UNKNOWN FORMAT(%u)",field_enum);
-		format_string = temp;
-	}
+	static char unknown_format[20];
+	sprintf(unknown_format, "UNKNOWN FORMAT(%u)",field_enum);
+	const char* format_string = (found_fe) ? fe_ptr->field_format : unknown_format;
 	proto_item* vff_item = proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, offset, count, -1, "[VFF] %s (%s) %s [length: %ld]",
 		vff_ptr->name, count_type, format_string, count);
 	proto_tree *vff_tree = proto_item_add_subtree(vff_item, ett_jaus_data);

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/packet-jaus.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/packet-jaus.c
@@ -99,6 +99,7 @@ int dissect_RA3_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree);
 int dissect_sdp_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree);
 int dissect_message_field(tvbuff_t *tvb, proto_tree *tree, field_t *f_ptr, int _op_count, guint64 presence_vector);
 int dissect_message_data(tvbuff_t *tvb, proto_tree *tree, int _offset, message_def_t *m_ptr);
+void dissect_embedded_message_data(tvbuff_t *tvb, proto_tree *tree, int offset);
 int get_number_of_bytes(char type);
 int get_data_from_tvb(tvbuff_t *tvb, int offset, char type, int size, guint64 *data);
 double scale_convert(unsigned int scaled_value, int bits, double real_lower, double real_upper, char int_function);
@@ -1276,31 +1277,7 @@ int dissect_variable_length_field(tvbuff_t *tvb, proto_tree *tree, variable_leng
 
 	if (strcmp(vlf_ptr->field_format, "JAUS MESSAGE") == 0)
 	{
-		message_def_t *m_ptr_sub;
-		bool found_sub_msg = false;
-		unsigned short sub_command = tvb_get_letohs(tvb, offset);
-
-		m_ptr_sub = message_set;
-		while (m_ptr_sub != NULL)
-		{
-			if (m_ptr_sub->message_id == sub_command)
-			{
-				found_sub_msg = true;
-				break;
-			}
-			m_ptr_sub = m_ptr_sub->next;
-		}
-
-		proto_item *sub_item = proto_tree_add_uint_format(
-			vlf_tree, hf_jaus_commandCode, tvb, offset, 2, sub_command,
-			"Command Code: %s (0x%04X)", (found_sub_msg) ? m_ptr_sub->name : "NotFoundInXML", sub_command);
-		offset += 2;
-		proto_tree *sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
-
-		if (found_sub_msg)
-		{
-			data_offset = dissect_message_data(tvb, sub_tree, offset, m_ptr_sub);
-		}
+		dissect_embedded_message_data(tvb, vlf_tree, offset);
 	}
 	else
 	{
@@ -1329,7 +1306,6 @@ int dissect_variable_format_field(tvbuff_t *tvb, proto_tree *tree, variable_form
 	offset += 1;
 
 	/* Find matching format_enum to data(index) pulled from buffer */
-	// TODO field_format seems to not be an ASCII string.
 	while (fe_ptr != NULL) {
 		if (field_enum == fe_ptr->index) {
 			found_fe = 1; break;
@@ -1346,49 +1322,30 @@ int dissect_variable_format_field(tvbuff_t *tvb, proto_tree *tree, variable_form
 
 	/* print with enum field_format name else error? with just the data from buffer */
 	const char *count_type = decode_field_type(cf_ptr->field_type_unsigned);
-	proto_item* vff_item = proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, offset, count, -1, "[VFF] %s (%s) %s [length: %ld]",
-		vff_ptr->name, count_type, (found_fe)? fe_ptr->field_format : "" , count);
-	proto_tree *vff_tree = proto_item_add_subtree(vff_item, ett_jaus_data);
-
-	if (field_enum == 0)
+	char* format_string;
+	if (found_fe)
 	{
-		// "JAUS MESSAGE"
-		message_def_t *m_ptr_sub;
-		bool found_sub_msg = false;
-		unsigned short sub_command = tvb_get_letohs(tvb, offset);
-
-		m_ptr_sub = message_set;
-		while (m_ptr_sub != NULL)
-		{
-			if (m_ptr_sub->message_id == sub_command)
-			{
-				found_sub_msg = true;
-				break;
-			}
-			m_ptr_sub = m_ptr_sub->next;
-		}
-
-		proto_item *sub_item = proto_tree_add_uint_format(
-			vff_tree, hf_jaus_commandCode, tvb, offset, 2, sub_command,
-			"Command Code: %s (0x%04X)", (found_sub_msg) ? m_ptr_sub->name : "NotFoundInXML", sub_command);
-		offset += 2;
-		proto_tree *sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
-
-		if (found_sub_msg)
-		{
-			data_offset = dissect_message_data(tvb, sub_tree, offset, m_ptr_sub);
-		}
-	}
-	else if (field_enum == 1)
-	{
-		// "User defined"
-		guint8 *data = ep_tvb_memdup(tvb, offset, (int)count);
-		proto_tree_add_bytes(vff_tree, hf_jaus_data, tvb, offset, ((int)count), data);
-		data_offset = (offset + (int)count);
+		format_string = fe_ptr->field_format;
 	}
 	else
 	{
-		// Undefined field enum
+		static char temp[25];
+		sprintf(temp, "UNKNOWN FORMAT(%u)",field_enum);
+		format_string = temp;
+	}
+	proto_item* vff_item = proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, offset, count, -1, "[VFF] %s (%s) %s [length: %ld]",
+		vff_ptr->name, count_type, format_string, count);
+	proto_tree *vff_tree = proto_item_add_subtree(vff_item, ett_jaus_data);
+
+	if (strcmp(fe_ptr->field_format, "JAUS MESSAGE") == 0)
+	{
+		dissect_embedded_message_data(tvb, vff_tree, offset);
+	}
+	else
+	{
+		guint8 *data = ep_tvb_memdup(tvb, offset, (int)count);
+		proto_tree_add_bytes(vff_tree, hf_jaus_data, tvb, offset, ((int)count), data);
+		data_offset = (offset + (int)count);
 	}
 
 	return(0);
@@ -1684,6 +1641,35 @@ int dissect_message_data(tvbuff_t *tvb, proto_tree *tree, int offset, message_de
 	}
 
 	return(data_offset);
+}
+
+void dissect_embedded_message_data(tvbuff_t *tvb, proto_tree *tree, int offset)
+{
+	message_def_t *sub_msg_ptr;
+	bool found_sub_msg = false;
+	unsigned short sub_command = tvb_get_letohs(tvb, offset);
+
+	sub_msg_ptr = message_set;
+	while (sub_msg_ptr != NULL)
+	{
+		if (sub_msg_ptr->message_id == sub_command)
+		{
+			found_sub_msg = true;
+			break;
+		}
+		sub_msg_ptr = sub_msg_ptr->next;
+	}
+
+	proto_item *sub_item = proto_tree_add_uint_format(
+		tree, hf_jaus_commandCode, tvb, offset, 2, sub_command,
+		"Command Code: %s (0x%04X)", (found_sub_msg) ? sub_msg_ptr->name : "NotFoundInXML", sub_command);
+	offset += 2;
+	proto_tree *sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+	if (found_sub_msg)
+	{
+		data_offset = dissect_message_data(tvb, sub_tree, offset, sub_msg_ptr);
+	}
 }
 
 /**

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/packet-jaus.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-3.2.x/packet-jaus.c
@@ -1316,33 +1316,81 @@ int dissect_variable_format_field(tvbuff_t *tvb, proto_tree *tree, variable_form
 	format_enum_t *fe_ptr;
 	count_field_t *cf_ptr;
 
-	guint64 data;
+	guint64 count;
+	int offset;
 	int size, found_fe = 0;
 	int error;
 
+	offset = data_offset;
 	fe_ptr = vff_ptr->format_enum;
 	cf_ptr = vff_ptr->count_field;
 
-	/* Get data field size and data from buffer */
-	size = get_number_of_bytes(cf_ptr->field_type_unsigned);
-	if (size < 0) {print_error(tvb, tree, size); return(size);}
-	error = get_data_from_tvb(tvb, data_offset, cf_ptr->field_type_unsigned, size, &data);
-	if (error < 0) {print_error(tvb, tree, error); return(error);}
-
+	const guint8 field_enum = tvb_get_guint8(tvb, offset);
+	offset += 1;
 
 	/* Find matching format_enum to data(index) pulled from buffer */
+	// TODO field_format seems to not be an ASCII string.
 	while (fe_ptr != NULL) {
-		if (data == fe_ptr->index) {
+		if (field_enum == fe_ptr->index) {
 			found_fe = 1; break;
 		}
 		fe_ptr = fe_ptr->next;
 	}
 
-	/* print with enum field_format name else error? with just the data from buffer */
-	proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[VFF] %s (%d) %s [index: %ld]",
-		vff_ptr->name, cf_ptr->field_type_unsigned, (found_fe)? fe_ptr->field_format : "" , data);
+	/* Get data field size and data from buffer */
+	size = get_number_of_bytes(cf_ptr->field_type_unsigned);
+	if (size < 0) {print_error(tvb, tree, size); return(size);}
+	error = get_data_from_tvb(tvb, offset, cf_ptr->field_type_unsigned, size, &count);
+	if (error < 0) {print_error(tvb, tree, error); return(error);}
+	offset += size;
 
-	data_offset += size;
+	/* print with enum field_format name else error? with just the data from buffer */
+	const char *count_type = decode_field_type(cf_ptr->field_type_unsigned);
+	proto_item* vff_item = proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, offset, count, -1, "[VFF] %s (%s) %s [length: %ld]",
+		vff_ptr->name, count_type, (found_fe)? fe_ptr->field_format : "" , count);
+	proto_tree *vff_tree = proto_item_add_subtree(vff_item, ett_jaus_data);
+
+	if (field_enum == 0)
+	{
+		// "JAUS MESSAGE"
+		message_def_t *m_ptr_sub;
+		bool found_sub_msg = false;
+		unsigned short sub_command = tvb_get_letohs(tvb, offset);
+
+		m_ptr_sub = message_set;
+		while (m_ptr_sub != NULL)
+		{
+			if (m_ptr_sub->message_id == sub_command)
+			{
+				found_sub_msg = true;
+				break;
+			}
+			m_ptr_sub = m_ptr_sub->next;
+		}
+
+		proto_item *sub_item = proto_tree_add_uint_format(
+			vff_tree, hf_jaus_commandCode, tvb, offset, 2, sub_command,
+			"Command Code: %s (0x%04X)", (found_sub_msg) ? m_ptr_sub->name : "NotFoundInXML", sub_command);
+		offset += 2;
+		proto_tree *sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+		if (found_sub_msg)
+		{
+			data_offset = dissect_message_data(tvb, sub_tree, offset, m_ptr_sub);
+		}
+	}
+	else if (field_enum == 1)
+	{
+		// "User defined"
+		guint8 *data = ep_tvb_memdup(tvb, offset, (int)count);
+		proto_tree_add_bytes(vff_tree, hf_jaus_data, tvb, offset, ((int)count), data);
+		data_offset = (offset + (int)count);
+	}
+	else
+	{
+		// Undefined field enum
+	}
+
 	return(0);
 }
 


### PR DESCRIPTION
Fixed parsing of the VariableFormatFields. The first byte is the field_enum that specifies the field format type. Based on the JSIDL, the next set of bytes is the length of the field and is based on the data type specified in the JSDIL. For the SetElement message, this a short, so two bytes.

This PR fixes the parse of the format and field length. Additionally, if the format is a "JAUS MESSAGE", this will also add that sub message to the tree for easier parsing.

<img width="568" height="269" alt="image" src="https://github.com/user-attachments/assets/55f874ad-bfe7-4761-bd52-c6dcb48ad706" />

There seems to be a problem with the jausxml interpretation of the `field_format` enum.

For the SetElement, the definition looks like:
```xml
<format_field>
    <format_enum index="0" field_format="JAUS MESSAGE"/>
    <format_enum index="1" field_format="User defined"/>
</format_field>
```

But as you can see in the picture the "field_format" string is a set of unprintable characters. I poked around for a bit, but settled on using the index values for now. Not sure if there are other VFFs with different enumerations. I'd prefer to get the parsing fixed to key off the field_name directly and not just the index.