### PR TITLE
Add plugin for 4.6

### DIFF
--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/CMakeLists.txt
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.16)
+project(JausDissector LANGUAGES C)
+
+find_package(Wireshark CONFIG REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(LibXml2)
+
+INCLUDE(UseMakePluginReg.cmake)
+
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GLIB2 REQUIRED glib-2.0)
+include_directories (${GLIB2_INCLUDE_DIRS} ${Wireshark_INCLUDE_DIR} ${LIBXML2_INCLUDE_DIR})
+
+set(LINK_MODE_LIB SHARED)
+set(LINK_MODE_MODULE MODULE)
+set(PLUGIN_VERSION "1.0.0")
+add_definitions(-DPLUGIN_VERSION=\"${PLUGIN_VERSION}\")
+
+set(DISSECTOR_SRC
+	packet-jaus.c
+	jausxml.c
+)
+
+set(PLUGIN_FILES
+	plugin.c
+	${DISSECTOR_SRC}
+)
+
+set_source_files_properties(
+	${PLUGIN_FILES}
+	PROPERTIES
+	COMPILE_FLAGS "${WERROR_COMMON_FLAGS}"
+)
+
+register_plugin_files(plugin.c
+	plugin
+	${DISSECTOR_SRC}
+)
+
+add_library(jaus ${LINK_MODE_MODULE}
+                  ${PLUGIN_FILES}
+                  ${PLUGIN_RC_FILE}
+)
+
+set_target_properties(jaus PROPERTIES
+		PREFIX ""
+		LINK_FLAGS "${WS_LINK_FLAGS}"
+		FOLDER "Plugins"
+)
+
+link_directories(${Wireshark_LIB_DIR})
+
+target_link_libraries(jaus wireshark)

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/README.md
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/README.md
@@ -1,0 +1,23 @@
+# JTS Wireshark Plugin
+
+This has been built and tested (a little) on Ubuntu 22.04 with Wireshark 4.6.4. Please submit any issues to <https://github.com/jaustoolset/jaustoolset/issues>.
+
+Beyond Wireshark, dependencies also include libxml2-dev.
+
+To build:
+
+1) Make a subdirectory under this one called Build: `mkdir Build`
+2) Change to it: `cd Build`
+3) Run CMake: `cmake ..`
+4) Compile: `make`
+5) Manually `sudo copy jaus.so <wireshark lib dir>/plugins/4.6/epan`
+
+For me `<wireshark lib dir>` = `/usr/lib/x86_64-linux-gnu`
+
+To verify the plugin:
+
+1) Open Wireshark
+2) Select Help->About Wireshark
+3) Verify that jaus.so is listed in the "Plugins" tab
+
+Don't forget to copy the JSIDL (XML) files from `packet-jaus-support/jausxml` to `/usr/local/lib/wireshark/packet-jaus-support/jausxml/`.

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/UseMakePluginReg.cmake
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/UseMakePluginReg.cmake
@@ -1,0 +1,16 @@
+function(register_plugin_files _outputfile _registertype)
+	file(RELATIVE_PATH output "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/${_outputfile}")
+	add_custom_command(
+	    OUTPUT
+	      ${_outputfile}
+	    COMMAND ${Python3_EXECUTABLE}
+	      ${CMAKE_SOURCE_DIR}/make-plugin-reg.py
+	      ${CMAKE_CURRENT_SOURCE_DIR}
+	      ${_registertype}
+	      ${ARGN}
+	    COMMENT "Generating ${output}"
+	    DEPENDS
+	      ${ARGN}
+	      ${CMAKE_SOURCE_DIR}/make-plugin-reg.py
+	)
+endfunction()

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/jausxml.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/jausxml.c
@@ -40,8 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <stdio.h>
-//#include <stdlib.h>
-//#include <math.h>
+#include <stdlib.h>
 #include <string.h>
 #include <dirent.h>
 

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/jausxml.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/jausxml.c
@@ -1,0 +1,1886 @@
+/***********           LICENSE HEADER   *******************************
+JAUS Tool Set
+Copyright (c)  2010, United States Government
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+       Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+       Redistributions in binary form must reproduce the above copyright 
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+
+       Neither the name of the United States Government nor the names of 
+its contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+*********************  END OF LICENSE ***********************************/
+
+/* jausxml.c
+ * Support Routines for Joint Architecture for Unmanned Systems (JAUS) dissection.
+ * 
+ * Updated 20 Jan 2011
+ *    - Linux updates
+ * Bug Fix 21 April 2011
+ *  Alex Evans <alex_evans@wintec-inc.com>
+ */
+
+#include <stdio.h>
+//#include <stdlib.h>
+//#include <math.h>
+#include <string.h>
+#include <dirent.h>
+
+#if _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "jausxml.h"
+
+#define DEBUG		0	/* Debug printouts if 1 not 0 */
+#define DEBUG1		0	/* printout to file messages read if 1 not 0 */
+#define DEBUG2		0	/* printout to file message tree if 1 not 0 */
+
+message_def_t *message_set = NULL;
+FILE *out;
+
+/**
+ * Add a new message_def to the message_set.
+ *
+ *
+ */
+message_def_t *add_message_def(char *name, unsigned short message_id, unsigned char is_command)
+{
+	message_def_t *tmp_ptr;
+
+	if (DEBUG) printf("add_message_def(): %s\n", name);
+
+	if (message_set == NULL) {
+		message_set = (message_def_t *)malloc(sizeof(message_def_t));
+
+		tmp_ptr = message_set;
+	}
+	else {
+		tmp_ptr = message_set;
+
+		while(tmp_ptr->next != NULL)
+			tmp_ptr = tmp_ptr->next;
+
+		tmp_ptr->next = (message_def_t *)malloc(sizeof(message_def_t));
+
+		tmp_ptr = tmp_ptr->next;
+	}
+
+	tmp_ptr->message_id = message_id;
+	strncpy(tmp_ptr->name, name, 64);
+	tmp_ptr->is_command = is_command;
+	tmp_ptr->header = NULL;
+	tmp_ptr->body = NULL;
+	tmp_ptr->footer = NULL;
+	tmp_ptr->next = NULL;
+
+	return tmp_ptr;
+}
+
+/**
+ * Add a field to any field_t pointer.
+ *
+ *
+ */
+void *add_field(field_t **field, unsigned char field_type)
+{
+	field_t *tmp_field;
+	int field_size;
+
+	if (DEBUG) printf("add_field(): field_type: %d\n", field_type);
+
+	switch (field_type) {
+		case ARRAY_TYPE:
+			field_size = sizeof(array_t); break;
+		case RECORD_TYPE:
+			field_size = sizeof(record_t); break;
+		case LIST_TYPE:
+			field_size = sizeof(list_t); break;
+		case VARIANT_TYPE:
+			field_size = sizeof(variant_t); break;
+		case SEQUENCE_TYPE:
+			field_size = sizeof(sequence_t); break;
+		case FIXED_FIELD_TYPE:
+			field_size = sizeof(fixed_field_t); break;
+		case VARIABLE_FIELD_TYPE:
+			field_size = sizeof(variable_field_t); break;
+		case BIT_FIELD_TYPE:
+			field_size = sizeof(bit_field_t); break;
+		case FIXED_LENGTH_STRING_TYPE:
+			field_size = sizeof(fixed_length_string_t); break;
+		case VARIABLE_LENGTH_STRING_TYPE:
+			field_size = sizeof(variable_length_string_t); break;
+		case VARIABLE_LENGTH_FIELD_TYPE:
+			field_size = sizeof(variable_length_field_t); break;
+		case VARIABLE_FORMAT_FIELD_TYPE:
+			field_size = sizeof(variable_format_field_t); break;
+		default:
+			return(NULL);
+	}
+
+	if ((*field) == NULL) { /* first field found */
+		if (DEBUG) printf("add_field(): first field  %d\n", field_size);
+
+		(*field) = (field_t *)malloc(sizeof(field_t));
+		(*field)->type = field_type;
+		(*field)->field = malloc(field_size);
+		(*field)->next = NULL;
+
+		if (DEBUG) printf("add_field(): exit 1\n");
+		return((*field)->field);
+
+	} else { /* another field found */
+		tmp_field = (*field);
+		if (DEBUG) printf("add_field(): another field  %d\n", field_size);
+
+		while (tmp_field->next != NULL) {
+			tmp_field = tmp_field->next;
+		}
+
+		tmp_field->next = (field_t *)malloc(sizeof(field_t));
+		tmp_field->next->type = field_type;
+		tmp_field->next->field = malloc(field_size);
+		tmp_field->next->next = NULL;
+
+		if (DEBUG) printf("add_field(): exit 2\n");
+		return(tmp_field->next->field);
+	}
+	if (DEBUG) printf("add_field(): BAD exit\n");
+	return(NULL);
+}
+
+/**
+ * Parses a message_def element.
+ *   Add it to the message_set
+ *   Read all fields
+ *
+ */
+void parse_message_def(xmlNode * message_node)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	message_def_t *message_def;
+
+	char *name;
+	unsigned short id;
+	unsigned char command;
+
+	if (DEBUG) printf("parse_message_def(): Enter\n");
+
+	/* Get the attributes for message_def */
+	for (cur_node = message_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    name = (char *)get_attr_value(cur_node);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"message_id"))) {
+			id = (unsigned short)strtol((char *)get_attr_value(cur_node), NULL, 16);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"is_command"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				command = 1;
+			else
+				command = 0;
+ 	    }
+	}
+
+	message_def = add_message_def(name, id, command);
+
+	/* read in all fields for this message */
+
+	/* header record */
+
+	/* body record */
+	next_node = find_child_node(message_node, "body");
+	for (next_node = next_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"record")))
+				parse_jaus_record(next_node, (record_t *)add_field(&message_def->body, RECORD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"list")))
+				parse_list(next_node, (list_t *)add_field(&message_def->body, LIST_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variant")))
+				parse_variant(next_node, (variant_t *)add_field(&message_def->body, VARIANT_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"sequence")))
+				parse_sequence(next_node, (sequence_t *)add_field(&message_def->body, SEQUENCE_TYPE));
+		}
+    }
+
+	/* footer record */
+
+}
+
+/**
+ * Parses a record element.
+ *
+ *   Read all fields
+ *
+ */
+void parse_jaus_record(xmlNode *record_node, record_t *record)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	if (DEBUG) printf("parse_jaus_record(): Enter\n");
+
+	/* Get the attributes for record */
+	for (cur_node = record_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(record->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				record->optional = 1;
+			else
+				record->optional = 0;
+ 	    }
+	}
+
+	record->field = NULL;
+	record->presence_vector_type = PDT_OP;
+
+	/* read in all fields for this message */
+
+	/* possible fields */
+	for (next_node = record_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"presence_vector"))) /* optional */
+				for (cur_node = next_node->properties; cur_node; cur_node = cur_node->next) {
+				    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_type_unsigned"))) {
+					    record->presence_vector_type = get_field_type((char *)get_attr_value(cur_node));
+			 	    }
+				}
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"array")))
+				parse_array(next_node, (array_t *)add_field(&record->field, ARRAY_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"fixed_field")))
+				parse_fixed_field(next_node, (fixed_field_t *)add_field(&record->field, FIXED_FIELD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variable_field")))
+				parse_variable_field(next_node, (variable_field_t *)add_field(&record->field, VARIABLE_FIELD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"bit_field")))
+				parse_bit_field(next_node, (bit_field_t *)add_field(&record->field, BIT_FIELD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"fixed_length_string")))
+				parse_fixed_length_string(next_node, (fixed_length_string_t *)add_field(&record->field, FIXED_LENGTH_STRING_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variable_length_string")))
+				parse_variable_length_string(next_node, (variable_length_string_t *)add_field(&record->field, VARIABLE_LENGTH_STRING_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variable_length_field")))
+				parse_variable_length_field(next_node, (variable_length_field_t *)add_field(&record->field, VARIABLE_LENGTH_FIELD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variable_format_field")))
+				parse_variable_format_field(next_node, (variable_format_field_t *)add_field(&record->field, VARIABLE_FORMAT_FIELD_TYPE));
+		}
+    }
+
+	if (DEBUG) printf("parse_jaus_record(): Exit\n");
+}
+
+/**
+ * Parses an array element.
+ *   Read all fields
+ *   Add it to the record
+ *
+ *
+ */
+void parse_array(xmlNode * a_node, array_t *array)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	dimension_t *tmp_ptr;
+
+	if (DEBUG) printf("parse_array(): Enter\n");
+
+	/* Get the attributes for fixed_field */
+	for (cur_node = a_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(array->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		/* optional
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(array->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    } */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				array->optional = 1;
+			else
+				array->optional = 0;
+ 	    }
+	}
+
+	array->field = NULL;
+	array->dimension = NULL;
+
+	/* possible fields */
+	for (next_node = a_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"fixed_field")))
+				parse_fixed_field(next_node, (fixed_field_t *)add_field(&array->field, FIXED_FIELD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variable_field")))
+				parse_variable_field(next_node, (variable_field_t *)add_field(&array->field, VARIABLE_FIELD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"bit_field")))
+				parse_bit_field(next_node, (bit_field_t *)add_field(&array->field, BIT_FIELD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"fixed_length_string")))
+				parse_fixed_length_string(next_node, (fixed_length_string_t *)add_field(&array->field, FIXED_LENGTH_STRING_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variable_length_string")))
+				parse_variable_length_string(next_node, (variable_length_string_t *)add_field(&array->field, VARIABLE_LENGTH_STRING_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variable_length_field")))
+				parse_variable_length_field(next_node, (variable_length_field_t *)add_field(&array->field, VARIABLE_LENGTH_FIELD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variable_format_field")))
+				parse_variable_format_field(next_node, (variable_format_field_t *)add_field(&array->field, VARIABLE_FORMAT_FIELD_TYPE));
+
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"dimension"))) {
+				if (array->dimension == NULL) { /* first dimension found */
+
+					array->dimension = (dimension_t *)malloc(sizeof(dimension_t));
+					array->dimension->next = NULL;
+					parse_dimension(next_node, array->dimension);
+
+				} else { /* another dimension found */
+
+					tmp_ptr = array->dimension;
+
+					while (tmp_ptr->next != NULL)
+						tmp_ptr = tmp_ptr->next;
+
+					tmp_ptr->next = (dimension_t *)malloc(sizeof(dimension_t));
+
+					tmp_ptr->next->next = NULL;
+					parse_dimension(next_node, tmp_ptr->next);
+				}
+			}
+		}
+    }
+}
+
+/**
+ * Parses a dimension element.
+ *
+ *
+ */
+void parse_dimension(xmlNode *d_node, dimension_t *dimension)
+{
+	xmlAttr *cur_node = NULL;
+
+	if (DEBUG) printf("parse_dimension(): Enter\n");
+
+	for (cur_node = d_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(dimension->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"size"))) {
+			dimension->size = (unsigned int)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		/* optional
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(dimension->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    } */
+	}
+}
+
+/**
+ * Parses a list element.
+ *
+ *   Read all fields
+ *
+ */
+void parse_list(xmlNode *l_node, list_t *list)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	if (DEBUG) printf("parse_list(): Enter\n");
+
+	for (cur_node = l_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(list->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				list->optional = 1;
+			else
+				list->optional = 0;
+ 	    }
+		/* optional
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(list->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    } */
+	}
+
+	list->count_field = NULL;
+	list->field = NULL;
+
+	next_node = find_child_node(l_node, "count_field");
+
+	if (next_node != NULL) {
+		list->count_field = (count_field_t *)malloc(sizeof(count_field_t));
+		parse_count_field(next_node, list->count_field);
+	}
+
+	for (next_node = l_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"record")))
+				parse_jaus_record(next_node, (record_t *)add_field(&list->field, RECORD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"list")))
+				parse_list(next_node, (list_t *)add_field(&list->field, LIST_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variant")))
+				parse_variant(next_node, (variant_t *)add_field(&list->field, VARIANT_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"sequence")))
+				parse_sequence(next_node, (sequence_t *)add_field(&list->field, SEQUENCE_TYPE));
+		}
+    }
+
+}
+
+/**
+ * Parses a variant element.
+ *
+ *   Read all fields
+ *
+ */
+void parse_variant(xmlNode *v_node, variant_t *variant)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	if (DEBUG) printf("parse_variant(): Enter\n");
+
+	for (cur_node = v_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(variant->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				variant->optional = 1;
+			else
+				variant->optional = 0;
+ 	    }
+		/* optional
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(variant->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    } */
+	}
+
+	variant->min_count = 0;
+	variant->max_count = 0;
+	variant->field = NULL;
+
+	next_node = find_child_node(v_node, "vtag_field");
+
+	/* Get the attributes for vtag_field */
+	for (cur_node = next_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_type_unsigned"))) {
+		    variant->field_type_unsigned =  get_field_type((char *)get_attr_value(cur_node));
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"min_count"))) {
+			variant->min_count = (unsigned int)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"max_count"))) {
+			variant->max_count = (unsigned int)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+	}
+
+	for (next_node = v_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"record")))
+				parse_jaus_record(next_node, (record_t *)add_field(&variant->field, RECORD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"list")))
+				parse_list(next_node, (list_t *)add_field(&variant->field, LIST_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variant")))
+				parse_variant(next_node, (variant_t *)add_field(&variant->field, VARIANT_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"sequence")))
+				parse_sequence(next_node, (sequence_t *)add_field(&variant->field, SEQUENCE_TYPE));
+		}
+    }
+}
+
+/**
+ * Parses a sequence element.
+ *
+ *   Read all fields
+ *
+ */
+void parse_sequence(xmlNode *s_node, sequence_t *sequence)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	if (DEBUG) printf("parse_sequence(): Enter\n");
+
+	for (cur_node = s_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(sequence->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				sequence->optional = 1;
+			else
+				sequence->optional = 0;
+ 	    }
+		/* optional
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(sequence->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    } */
+	}
+
+	sequence->presence_vector_type = PDT_OP;
+	sequence->field = NULL;
+
+	for (next_node = s_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"presence_vector"))) /* optional */
+				for (cur_node = next_node->properties; cur_node; cur_node = cur_node->next) {
+				    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_type_unsigned"))) {
+					    sequence->presence_vector_type = get_field_type((char *)get_attr_value(cur_node));
+			 	    }
+				}
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"record")))
+				parse_jaus_record(next_node, (record_t *)add_field(&sequence->field, RECORD_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"list")))
+				parse_list(next_node, (list_t *)add_field(&sequence->field, LIST_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"variant")))
+				parse_variant(next_node, (variant_t *)add_field(&sequence->field, VARIANT_TYPE));
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"sequence")))
+				parse_sequence(next_node, (sequence_t *)add_field(&sequence->field, SEQUENCE_TYPE));
+		}
+    }
+
+}
+
+/**
+ * Parses a fixed_field element.
+ *   Read all fields
+ *
+ *
+ */
+void parse_fixed_field(xmlNode * ff_node, fixed_field_t *fixed_field)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	if (DEBUG) printf("parse_fixed_field(): Enter\n");
+
+	strncpy(fixed_field->interpretation, "none", 64);
+
+	/* Get the attributes for fixed_field */
+	for (cur_node = ff_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(fixed_field->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_type"))) {
+			fixed_field->field_type = get_field_type((char *)get_attr_value(cur_node));
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_units"))) {
+			strncpy(fixed_field->field_units, (char *)get_attr_value(cur_node), 32);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(fixed_field->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				fixed_field->optional = 1;
+			else
+				fixed_field->optional = 0;
+ 	    }
+	}
+
+	fixed_field->scale_range = NULL;
+	fixed_field->value_set = NULL;
+
+	/* fields */
+	for (next_node = ff_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"scale_range"))) {
+
+				fixed_field->scale_range = (scale_range_t *)malloc(sizeof(scale_range_t));
+
+				parse_scale_range(next_node, fixed_field->scale_range);
+
+			}
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"value_set"))) {
+
+				fixed_field->value_set = (value_set_t *)malloc(sizeof(value_set_t));
+
+				parse_value_set(next_node, fixed_field->value_set);
+			}
+		}
+    }
+}
+
+/**
+ * Parses a scale_range element.
+ *
+ *
+ */
+void parse_scale_range(xmlNode *a_node, scale_range_t *field_ptr)
+{
+	xmlAttr *cur_node = NULL;
+	char *value;
+
+	if (DEBUG) printf("parse_scale_range(): Enter\n");
+
+	/* NULL the optional attributes */
+
+	/* Get the attributes for scale_range */
+	for (cur_node = a_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"integer_function"))) {
+		value = (char *)get_attr_value(cur_node);
+			if ((!strcmp(value, "round")))
+				field_ptr->integer_function = ROUND;
+			else if ((!strcmp(value, "floor")))
+				field_ptr->integer_function = FLOOR;
+			else
+				field_ptr->integer_function = CEILING;
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"real_lower_limit"))) {
+		    field_ptr->real_lower_limit = strtod((char *)get_attr_value(cur_node), NULL);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"real_upper_limit"))) {
+		    field_ptr->real_upper_limit = strtod((char *)get_attr_value(cur_node), NULL);
+ 	    }
+	}
+}
+
+/**
+ * Parses a bit_field element.
+ *   Read all fields
+ *   Add it to the record
+ *
+ */
+void parse_bit_field(xmlNode * bf_node, bit_field_t *bit_field)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	sub_field_t *tmp_ptr;
+
+	if (DEBUG) printf("parse_bit_field(): Enter\n");
+
+	/* Get the attributes for bit_field */
+	for (cur_node = bf_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(bit_field->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_type_unsigned"))) {
+			bit_field->field_type_unsigned = get_field_type((char *)get_attr_value(cur_node));
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				bit_field->optional = 1;
+			else
+				bit_field->optional = 0;
+ 	    }
+	}
+
+	bit_field->sub_field = NULL;
+
+	/* fields */
+	for (next_node = bf_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"sub_field"))) {
+				if (bit_field->sub_field == NULL) { /* first sub_field found */
+
+					bit_field->sub_field = (sub_field_t *)malloc(sizeof(sub_field_t));
+					bit_field->sub_field->next = NULL;
+					parse_sub_field(next_node, bit_field->sub_field);
+
+				} else { /* another sub_field found */
+
+					tmp_ptr = bit_field->sub_field;
+
+					while (tmp_ptr->next != NULL)
+						tmp_ptr = tmp_ptr->next;
+
+					tmp_ptr->next = (sub_field_t *)malloc(sizeof(sub_field_t));
+
+					tmp_ptr->next->next = NULL;
+					parse_sub_field(next_node, tmp_ptr->next);
+				}
+			}
+		}
+    }
+    
+	if (DEBUG) printf("parse_bit_field(): Exit\n");
+}
+
+/**
+ * Parses a sub_field element.
+ *   Read all fields
+ *
+ *
+ */
+void parse_sub_field(xmlNode * sf_node, sub_field_t *sub_field)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	value_range_t *tmp_ptr;
+	value_enum_t *etmp_ptr;
+
+	if (DEBUG) printf("parse_sub_field(): Enter\n");
+
+	/* Get the attributes for sub_field */
+	for (cur_node = sf_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(sub_field->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+	}
+
+	next_node = find_child_node(sf_node, "bit_range");
+
+	/* Get the attributes for bit_field */
+	for (cur_node = next_node->properties; cur_node; cur_node = cur_node->next) {
+		if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"from_index"))) {
+		    sub_field->from_index = (unsigned char)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"to_index"))) {
+			sub_field->to_index = (unsigned char)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+	}
+
+	next_node = find_child_node(sf_node, "value_set");
+
+	/* Get the attributes for value_set */
+	for (cur_node = next_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"offset_to_lower_limit"))) {
+		    if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				sub_field->offset_to_lower_limit = 1;
+			else
+				sub_field->offset_to_lower_limit = 0;
+ 	    }
+	}
+
+	sub_field->value_range = NULL;
+	sub_field->value_enum = NULL;
+
+	/* fields */
+	for (next_node = next_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"value_range"))) {
+				if (sub_field->value_range == NULL) { /* first value_range found */
+
+					sub_field->value_range = (value_range_t *)malloc(sizeof(value_range_t));
+					sub_field->value_range->next = NULL;
+					parse_value_range(next_node, sub_field->value_range);
+
+				} else { /* another value_range found */
+					tmp_ptr = sub_field->value_range;
+
+					while (tmp_ptr->next != NULL)
+						tmp_ptr = tmp_ptr->next;
+
+					tmp_ptr->next = (value_range_t *)malloc(sizeof(value_range_t));
+					tmp_ptr->next->next = NULL;
+					parse_value_range(next_node, tmp_ptr->next);
+				}
+			} else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"value_enum"))) {
+				if (sub_field->value_enum == NULL) { /* first value_enum found */
+
+					sub_field->value_enum = (value_enum_t *)malloc(sizeof(value_enum_t));
+					sub_field->value_enum->next = NULL;
+					parse_value_enum(next_node, sub_field->value_enum);
+
+				} else { /* another value_enum found */
+					etmp_ptr = sub_field->value_enum;
+
+					while (etmp_ptr->next != NULL)
+						etmp_ptr = etmp_ptr->next;
+
+					etmp_ptr->next = (value_enum_t *)malloc(sizeof(value_enum_t));
+					etmp_ptr->next->next = NULL;
+					parse_value_enum(next_node, etmp_ptr->next);
+				}
+			}
+		}
+    }
+    
+	if (DEBUG) printf("parse_sub_field(): Exit\n");
+}
+
+/**
+ * Parses a value_range element.
+ *
+ *
+ */
+void parse_value_range(xmlNode *vr_node, value_range_t *value_range)
+{
+	xmlAttr *cur_node = NULL;
+
+	if (DEBUG) printf("parse_value_range(): Enter\n");
+
+	strncpy(value_range->interpretation, "none", 64);
+
+	/* Get the attributes for value_range */
+	for (cur_node = vr_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"lower_limit"))) {
+		    value_range->lower_limit = (int)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"upper_limit"))) {
+			value_range->upper_limit = (int)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"lower_limit_type"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"inclusive")))
+				value_range->lower_limit_type = INCLUSIVE;
+			else /* exclusive */
+				value_range->lower_limit_type = EXCLUSIVE;
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"upper_limit_type"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"inclusive")))
+				value_range->upper_limit_type = INCLUSIVE;
+			else /* exclusive */
+				value_range->upper_limit_type = EXCLUSIVE;
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(value_range->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    }
+	}
+
+}
+
+/**
+ * Parses a value_enum element.
+ *
+ *
+ */
+void parse_value_enum(xmlNode *ve_node, value_enum_t *value_enum)
+{
+	xmlAttr *cur_node = NULL;
+
+	if (DEBUG) printf("parse_value_enum(): Enter\n");
+
+	/* Get the attributes for value_enum */
+	for (cur_node = ve_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"enum_index"))) {
+		    value_enum->enum_index = strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"enum_const"))) {
+			strncpy(value_enum->enum_const, (char *)get_attr_value(cur_node), 64);
+ 	    }
+	}
+
+	if (DEBUG) printf("parse_value_enum(): Exit\n");
+}
+
+/**
+ * Parses a value_set element.
+ *
+ *
+ */
+void parse_value_set(xmlNode *vs_node, value_set_t *value_set)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	value_range_t *tmp_ptr;
+	value_enum_t *etmp_ptr;
+
+	if (DEBUG) printf("parse_value_set(): Enter\n");
+
+	/* Get the attributes for value_set */
+	for (cur_node = vs_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"offset_to_lower_limit"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				value_set->offset_to_lower_limit = 1;
+			else
+				value_set->offset_to_lower_limit = 0;
+ 	    }
+	}
+
+	value_set->value_range = NULL;
+	value_set->value_enum = NULL;
+
+	/* fields */
+	for (next_node = vs_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"value_range"))) {
+				if (value_set->value_range == NULL) { /* first value_range found */
+
+					value_set->value_range = (value_range_t *)malloc(sizeof(value_range_t));
+					value_set->value_range->next = NULL;
+					parse_value_range(next_node, value_set->value_range);
+
+				} else { /* another value_range found */
+					tmp_ptr = value_set->value_range;
+
+					while (tmp_ptr->next != NULL)
+						tmp_ptr = tmp_ptr->next;
+
+					tmp_ptr->next = (value_range_t *)malloc(sizeof(value_range_t));
+					tmp_ptr->next->next = NULL;
+					parse_value_range(next_node, tmp_ptr->next);
+				}
+			} else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"value_enum"))) {
+				if (value_set->value_enum == NULL) { /* first value_enum found */
+
+					value_set->value_enum = (value_enum_t *)malloc(sizeof(value_enum_t));
+					value_set->value_enum->next = NULL;
+					parse_value_enum(next_node, value_set->value_enum);
+
+				} else { /* another value_enum found */
+					etmp_ptr = value_set->value_enum;
+
+					while (etmp_ptr->next != NULL)
+						etmp_ptr = etmp_ptr->next;
+
+					etmp_ptr->next = (value_enum_t *)malloc(sizeof(value_enum_t));
+					etmp_ptr->next->next = NULL;
+					parse_value_enum(next_node, etmp_ptr->next);
+				}
+			}
+		}
+    }
+
+	if (DEBUG) printf("parse_value_set(): Exit\n");
+}
+
+/**
+ * Parses a fixed_field element.
+ *   Read all fields
+ *   Add it to the record
+ *
+ */
+void parse_variable_field(xmlNode * vf_node, variable_field_t *variable_field)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+	xmlNode *taue_node = NULL;
+
+	type_and_units_enum_t *tmp_ptr;
+
+	if (DEBUG) printf("parse_variable_field(): Enter\n");
+
+	strncpy(variable_field->interpretation, "none", 64);
+
+	/* Get the attributes for variable_field */
+	for (cur_node = vf_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(variable_field->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(variable_field->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				variable_field->optional = 1;
+			else
+				variable_field->optional = 0;
+ 	    }
+	}
+
+	variable_field->taue = NULL;
+
+	/* fields */
+	for (next_node = vf_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"type_and_units_field"))) {
+
+				for (taue_node = next_node->children; taue_node; taue_node = taue_node->next) {
+        			if (taue_node->type == XML_ELEMENT_NODE) {
+						if ((!xmlStrcmp(taue_node->name, (const xmlChar *)"type_and_units_enum"))) {
+							if (variable_field->taue == NULL) { /* first type_and_units_enum found */
+
+								variable_field->taue = (type_and_units_enum_t *)malloc(sizeof(type_and_units_enum_t));
+
+								variable_field->taue->next = NULL;
+								parse_type_and_units_enum(taue_node, variable_field->taue);
+
+							} else { /* another type_and_units_enum found */
+								tmp_ptr = variable_field->taue;
+
+								while (tmp_ptr->next != NULL)
+									tmp_ptr = tmp_ptr->next;
+
+								tmp_ptr->next = (type_and_units_enum_t *)malloc(sizeof(type_and_units_enum_t));
+								tmp_ptr->next->next = NULL;
+								parse_type_and_units_enum(taue_node, tmp_ptr->next);
+							}
+						}
+					}
+				}
+			}
+		}
+    }
+    
+	if (DEBUG) printf("parse_variable_field(): Exit\n");
+}
+
+/**
+ * Parses a type_and_units_enum element.
+ *
+ *
+ */
+void parse_type_and_units_enum(xmlNode *taue_node, type_and_units_enum_t *taue)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	if (DEBUG) printf("parse_type_and_units_enum(): Enter\n");
+
+	/* Get the attributes for type_and_units_enum */
+	for (cur_node = taue_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"index"))) {
+		    taue->index = (unsigned char)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_type"))) {
+			taue->field_type = get_field_type((char *)get_attr_value(cur_node));
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_units"))) {
+			strncpy(taue->field_units, (char *)get_attr_value(cur_node), 32);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+			strncpy(taue->name, (char *)get_attr_value(cur_node), 32);
+ 	    }
+	}
+
+	taue->value_set = NULL;
+	taue->scale_range = NULL;
+
+	/* fields */
+	for (next_node = taue_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"value_set"))) {
+
+				taue->value_set = (value_set_t *)malloc(sizeof(value_set_t));
+				parse_value_set(next_node, taue->value_set);
+			}
+			else if ((!xmlStrcmp(next_node->name, (const xmlChar *)"scale_range"))) {
+
+				taue->scale_range = (scale_range_t *)malloc(sizeof(scale_range_t));
+				parse_scale_range(next_node, taue->scale_range);
+			}
+		}
+    }
+
+	if (DEBUG) printf("parse_type_and_units_enum(): Exit\n");
+}
+
+/**
+ * Parses a fixed_length_string element.
+ *   Add it to the record
+ *
+ */
+void parse_fixed_length_string(xmlNode * fls_node, fixed_length_string_t *fixed_length_string)
+{
+	xmlAttr *cur_node = NULL;
+
+	if (DEBUG) printf("parse_fixed_length_string(): Enter\n");
+
+	strncpy(fixed_length_string->interpretation, "none", 64);
+
+	/* Get the attributes for fixed_length_sting */
+	for (cur_node = fls_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(fixed_length_string->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"string_length"))) {
+			fixed_length_string->string_length = (unsigned int)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(fixed_length_string->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				fixed_length_string->optional = 1;
+			else
+				fixed_length_string->optional = 0;
+ 	    }
+	}
+    
+	if (DEBUG) printf("parse_fixed_length_string(): Exit\n");
+}
+
+/**
+ * Parses a variable_length_string element.
+ *   Add it to the record
+ *
+ */
+void parse_variable_length_string(xmlNode * vls_node, variable_length_string_t *variable_length_string)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	if (DEBUG) printf("parse_variable_length_string(): Enter\n");
+
+	strncpy(variable_length_string->interpretation, "none", 64);
+
+	/* Get the attributes for variable_length_string */
+	for (cur_node = vls_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(variable_length_string->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(variable_length_string->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				variable_length_string->optional = 1;
+			else
+				variable_length_string->optional = 0;
+ 	    }
+	}
+
+	variable_length_string->count_field = NULL;
+
+	next_node = find_child_node(vls_node, "count_field");
+
+	if (next_node != NULL) {
+		variable_length_string->count_field = (count_field_t *)malloc(sizeof(count_field_t));
+		parse_count_field(next_node, variable_length_string->count_field);
+	}
+    
+	if (DEBUG) printf("parse_variable_length_string(): Exit\n");
+}
+
+/**
+ * Parses a count_field element.
+ *
+ *
+ */
+void parse_count_field(xmlNode *cf_node, count_field_t *count_field)
+{
+	xmlAttr *cur_node = NULL;
+
+	if (DEBUG) printf("parse_count_field(): Enter\n");
+
+	strncpy(count_field->interpretation, "none", 64);
+	count_field->min_count = 0;
+	count_field->max_count = 0;
+
+	/* Get the attributes for count_field */
+	for (cur_node = cf_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_type_unsigned"))) {
+		    count_field->field_type_unsigned =  get_field_type((char *)get_attr_value(cur_node));
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"min_count"))) {
+			count_field->min_count = (unsigned int)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"max_count"))) {
+			count_field->max_count = (unsigned int)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(count_field->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    }
+	}
+    
+	if (DEBUG) printf("parse_count_field(): Exit\n");
+}
+
+/**
+ * Parses a variable_length_field element.
+ *
+ *
+ */
+void parse_variable_length_field(xmlNode *vlf_node, variable_length_field_t *variable_length_field)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	if (DEBUG) printf("parse_variable_length_field(): Enter\n");
+
+	strncpy(variable_length_field->interpretation, "none", 64);
+
+	/* Get the attributes for variable_length_field */
+	for (cur_node = vlf_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(variable_length_field->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_format"))) {
+			strncpy(variable_length_field->field_format, (char *)get_attr_value(cur_node), 15);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(variable_length_field->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				variable_length_field->optional = 1;
+			else
+				variable_length_field->optional = 0;
+ 	    }
+	}
+
+	variable_length_field->count_field = NULL;
+
+	next_node = find_child_node(vlf_node, "count_field");
+
+	if (next_node != NULL) {
+		variable_length_field->count_field = (count_field_t *)malloc(sizeof(count_field_t));
+		parse_count_field(next_node, variable_length_field->count_field);
+	}
+    
+    if (DEBUG) printf("parse_variable_length_field(): Exit\n");
+}
+
+/**
+ * Parses a variable_format_field element.
+ *
+ *
+ */
+void parse_variable_format_field(xmlNode *vff_node, variable_format_field_t *variable_format_field)
+{
+	xmlAttr *cur_node = NULL;
+	xmlNode *next_node = NULL;
+
+	format_enum_t *tmp_ptr;
+
+	if (DEBUG) printf("parse_variable_format_field(): Enter\n");
+
+	strncpy(variable_format_field->interpretation, "none", 64);
+
+	/* Get the attributes for variable_format_field */
+	for (cur_node = vff_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"name"))) {
+		    strncpy(variable_format_field->name, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		/* optional */
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"interpretation"))) {
+			strncpy(variable_format_field->interpretation, (char *)get_attr_value(cur_node), 64);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"optional"))) {
+			if ((!xmlStrcmp(get_attr_value(cur_node), (const xmlChar *)"true")))
+				variable_format_field->optional = 1;
+			else
+				variable_format_field->optional = 0;
+ 	    }
+	}
+
+	variable_format_field->format_enum = NULL;
+
+	next_node = find_child_node(vff_node, "format_field");
+
+	/* fields */
+	for (next_node = next_node->children; next_node; next_node = next_node->next) {
+        if (next_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(next_node->name, (const xmlChar *)"format_enum"))) {
+				if (variable_format_field->format_enum == NULL) { /* first format_enum found */
+
+					variable_format_field->format_enum = (format_enum_t *)malloc(sizeof(format_enum_t));
+					variable_format_field->format_enum->next = NULL;
+					parse_format_enum(next_node, variable_format_field->format_enum);
+
+				} else { /* another format_enum found */
+					tmp_ptr = variable_format_field->format_enum;
+
+					while (tmp_ptr->next != NULL)
+						tmp_ptr = tmp_ptr->next;
+
+					tmp_ptr->next = (format_enum_t *)malloc(sizeof(format_enum_t));
+					tmp_ptr->next->next = NULL;
+                    
+					parse_format_enum(next_node, tmp_ptr->next);
+				}
+			}
+		}
+    }
+
+	variable_format_field->count_field = NULL;
+
+	next_node = find_child_node(vff_node, "count_field");
+
+	if (next_node != NULL) {
+		variable_format_field->count_field = (count_field_t *)malloc(sizeof(count_field_t));
+		parse_count_field(next_node, variable_format_field->count_field);
+	}
+    
+    if (DEBUG) printf("parse_variable_format_field(): Exit\n");
+}
+
+/**
+ * Parses a format_enum element.
+ *
+ *
+ */
+void parse_format_enum(xmlNode *fe_node, format_enum_t *format_enum)
+{
+	xmlAttr *cur_node = NULL;
+
+	if (DEBUG) printf("parse_format_enum(): Enter\n");
+
+	/* Get the attributes for format_enum */
+	for (cur_node = fe_node->properties; cur_node; cur_node = cur_node->next) {
+	    if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"index"))) {
+			format_enum->index = (unsigned char)strtol((char *)get_attr_value(cur_node), NULL, 10);
+ 	    }
+		else if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"field_format"))) {
+			strncpy(format_enum->field_format, (char *)get_attr_value(cur_node), 15);
+ 	    }
+	}
+    
+	if (DEBUG) printf("parse_format_enum(): Exit\n");
+}
+
+
+
+char get_field_type(char* type)
+{
+	if ((!strcmp(type, "byte")))
+		return(PDT_BYTE);
+	else if ((!strcmp(type, "short integer")))
+		return(PDT_SHORT_INT);
+	else if ((!strcmp(type, "integer")))
+		return(PDT_INT);
+	else if ((!strcmp(type, "long integer")))
+		return(PDT_LONG_INT);
+	else if ((!strcmp(type, "unsigned byte")))
+		return(PDT_UBYTE);
+	else if ((!strcmp(type, "unsigned short integer")))
+		return(PDT_USHORT_INT);
+	else if ((!strcmp(type, "unsigned integer")))
+		return(PDT_UINT);
+	else if ((!strcmp(type, "unsigned long integer")))
+		return(PDT_ULONG_INT);
+	else if ((!strcmp(type, "float")))
+		return(PDT_FLOAT);
+	else if ((!strcmp(type, "long float")))
+		return(PDT_LONG_FLOAT);
+	return(PDT_BAD);
+}
+
+/**
+ * Gets the name of an attribute node.
+ *
+ * Returns the name of the attribute.
+ */
+static const xmlChar* get_attr_name(xmlAttr * a_node)
+{
+	if (a_node->type == XML_ATTRIBUTE_NODE) {
+		return(a_node->name);
+	}
+
+    return(NULL);
+}
+
+/**
+ * Gets the content of an attribute node.
+ *
+ * Returns the content of the attribute.
+ */
+static const xmlChar* get_attr_value(xmlAttr * a_node)
+{
+	if (a_node->type == XML_ATTRIBUTE_NODE) {
+		return(a_node->children->content);
+	}
+
+    return(NULL);
+}
+
+/**
+ * Finds the next node with the given name.
+ *
+ * Returns the pointer to the node.
+ */
+xmlNode *find_child_node(xmlNode * a_node, char *name)
+{
+	xmlNode *cur_node = NULL;
+	if (DEBUG) printf("find_child_node(): Enter\n");
+	for (cur_node = a_node->children; cur_node; cur_node = cur_node->next) {
+        if (cur_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(cur_node->name, (const xmlChar *)name)))
+			{
+				if (DEBUG) printf("find_child_node(): Found Node name: %s\n", cur_node->name);
+				return(cur_node);
+			}
+		} else if (DEBUG) printf("find_child_node(): Not ELEMENT (%d)\n",cur_node->type);
+
+    }
+	return(NULL);
+}
+
+/**
+ * Finds the first node for message_def and starts the parser then loops till
+ *  no more message_def elements are found.
+ *
+ *
+ */
+void read_message_defs(xmlNode * a_node)
+{
+	xmlNode *cur_node = NULL;
+
+	for (cur_node = a_node; cur_node; cur_node = cur_node->next) {
+        if (cur_node->type == XML_ELEMENT_NODE) {
+			if ((!xmlStrcmp(cur_node->name, (const xmlChar *)"message_def")))
+			{
+				if (DEBUG) printf("read_message_defs(): Found name: %s\n", cur_node->name);
+				parse_message_def(cur_node);
+			}
+		}else if (DEBUG) printf("read_message_defs(): Not ELEMENT (%d)\n",cur_node->type);
+
+		if ((xmlStrcmp(cur_node->name, (const xmlChar *)"message_def")))
+			read_message_defs(cur_node->children);
+    }
+
+}
+
+void test_print_field(field_t *f_ptr, int f_count)
+{
+	array_t *a_ptr;
+	dimension_t *d_ptr;
+
+	fixed_field_t *ff_ptr;
+	scale_range_t *sr_ptr;
+	value_set_t *vs_ptr;
+		value_range_t *vr_ptr;
+		value_enum_t *ve_ptr;
+
+	variable_field_t *vf_ptr;
+	type_and_units_enum_t *taue_ptr;
+
+	bit_field_t *bf_ptr;
+	sub_field_t *sf_ptr;
+
+	fixed_length_string_t *fls_ptr;
+
+	variable_length_string_t *vls_ptr;
+	count_field_t *cf_ptr;
+
+	variable_length_field_t *vlf_ptr;
+
+	variable_format_field_t *vff_ptr;
+	format_enum_t *fe_ptr;
+
+
+	/* fprintf(out," Field Type: %d\n", f_ptr->type); */
+	switch (f_ptr->type) {
+		case ARRAY_TYPE:
+			a_ptr = (array_t *)f_ptr->field;
+			fprintf(out,"\n      [%d A] %s (%s) \n", f_count, a_ptr->name, (a_ptr->optional) ? "optional" : "req");
+			d_ptr = a_ptr->dimension;
+			while (d_ptr != NULL) {
+				fprintf(out,"      [d] %s  %d \n", d_ptr->name, d_ptr->size);
+				d_ptr = d_ptr->next;
+			}
+			test_print_field(a_ptr->field, f_count);
+			break;
+		case FIXED_FIELD_TYPE:
+			ff_ptr = (fixed_field_t *)f_ptr->field;
+			fprintf(out,"\n      [%d FF] %s (ft:%d) %s (%s)\n        %s\n", f_count,
+				ff_ptr->name, ff_ptr->field_type, ff_ptr->field_units,
+				(ff_ptr->optional) ? "optional" : "req", ff_ptr->interpretation);
+			if (ff_ptr->scale_range != NULL) {
+				sr_ptr = ff_ptr->scale_range;
+				fprintf(out,"        [SR] upper %f lower %f func %d\n", sr_ptr->real_upper_limit, sr_ptr->real_lower_limit,
+					sr_ptr->integer_function);
+			}
+			if (ff_ptr->value_set != NULL) {
+				vs_ptr = ff_ptr->value_set;
+				fprintf(out,"        [VS] offset_to_lower: %s\n",(vs_ptr->offset_to_lower_limit)? "True":"False");
+				vr_ptr = vs_ptr->value_range;
+				ve_ptr = vs_ptr->value_enum;
+				while (vr_ptr != NULL) {
+					fprintf(out,"          [VR] lower: %d (%s) upper: %d (%s) inter: %s\n", vr_ptr->lower_limit, (vr_ptr->lower_limit_type)?"exclusive":"inclusive",
+						vr_ptr->upper_limit, (vr_ptr->upper_limit_type)?"exclusive":"inclusive", vr_ptr->interpretation);
+					vr_ptr = vr_ptr->next;
+				}
+				while (ve_ptr != NULL) {
+					fprintf(out,"          [VE] index: %ld const: %s\n", ve_ptr->enum_index, ve_ptr->enum_const);
+					ve_ptr = ve_ptr->next;
+				}
+			}
+			break;
+		case VARIABLE_FIELD_TYPE:
+			vf_ptr = (variable_field_t *)f_ptr->field;
+			fprintf(out,"\n      [%d VF] %s (%s)\n        %s\n", f_count,
+				vf_ptr->name, (vf_ptr->optional) ? "optional" : "req", vf_ptr->interpretation);
+			if (vf_ptr->taue != NULL) {
+				taue_ptr = vf_ptr->taue;
+				while (taue_ptr != NULL) {
+					fprintf(out,"        [TAUE]: index %d (ft:%d) %s\n", taue_ptr->index, taue_ptr->field_type,
+						taue_ptr->field_units);
+					if (taue_ptr->scale_range != NULL) {
+						sr_ptr = taue_ptr->scale_range;
+						fprintf(out,"        [SR] upper %f lower %f func %d\n", sr_ptr->real_upper_limit, sr_ptr->real_lower_limit,
+							sr_ptr->integer_function);
+					}
+					if (taue_ptr->value_set != NULL) {
+						vs_ptr = taue_ptr->value_set;
+						fprintf(out,"        [VS] offset_to_lower: %s\n",(vs_ptr->offset_to_lower_limit)? "True":"False");
+						vr_ptr = vs_ptr->value_range;
+						ve_ptr = vs_ptr->value_enum;
+						while (vr_ptr != NULL) {
+							fprintf(out,"          [VR] lower: %d (%s) upper: %d (%s) inter: %s\n", vr_ptr->lower_limit, (vr_ptr->lower_limit_type)?"exclusive":"inclusive",
+								vr_ptr->upper_limit, (vr_ptr->upper_limit_type)?"exclusive":"inclusive", vr_ptr->interpretation);
+							vr_ptr = vr_ptr->next;
+						}
+						while (ve_ptr != NULL) {
+							fprintf(out,"          [VE] index: %ld const: %s\n", ve_ptr->enum_index, ve_ptr->enum_const);
+							ve_ptr = ve_ptr->next;
+						}
+					}
+					taue_ptr = taue_ptr->next;
+				}
+			}
+			break;
+		case BIT_FIELD_TYPE:
+			bf_ptr = (bit_field_t *)f_ptr->field;
+			fprintf(out,"\n      [%d BF] %s (ft:%d) (%s)\n", f_count, bf_ptr->name, bf_ptr->field_type_unsigned,
+				(bf_ptr->optional) ? "optional" : "req");
+			sf_ptr = bf_ptr->sub_field;
+			while (sf_ptr != NULL) {
+				fprintf(out,"       [SF]: %s from: %d to: %d offset_to_low: %s\n", sf_ptr->name, sf_ptr->from_index,
+					sf_ptr->to_index, (sf_ptr->offset_to_lower_limit) ? "yes" : "no");
+				vr_ptr = sf_ptr->value_range;
+				ve_ptr = sf_ptr->value_enum;
+				while (vr_ptr != NULL) {
+					fprintf(out,"         [VR] lower: %d (%s) upper: %d (%s) inter: %s\n", vr_ptr->lower_limit, (vr_ptr->lower_limit_type)?"exclusive":"inclusive",
+						vr_ptr->upper_limit, (vr_ptr->upper_limit_type)?"exclusive":"inclusive", vr_ptr->interpretation);
+					vr_ptr = vr_ptr->next;
+				}
+				while (ve_ptr != NULL) {
+					fprintf(out,"         [VE] index: %ld const: %s\n", ve_ptr->enum_index, ve_ptr->enum_const);
+					ve_ptr = ve_ptr->next;
+				}
+				sf_ptr = sf_ptr->next;
+			}
+			break;
+		case FIXED_LENGTH_STRING_TYPE:
+			fls_ptr = (fixed_length_string_t *)f_ptr->field;
+			fprintf(out,"\n      [%d FLS] %s (sl:%d) (%s)\n", f_count, fls_ptr->name, fls_ptr->string_length,
+				(fls_ptr->optional) ? "optional" : "req");
+			break;
+		case VARIABLE_LENGTH_STRING_TYPE:
+			vls_ptr = (variable_length_string_t *)f_ptr->field;
+			fprintf(out,"\n      [%d VLS] %s (%s)\n", f_count, vls_ptr->name, (vls_ptr->optional) ? "optional" : "req");
+			cf_ptr = vls_ptr->count_field;
+			if (cf_ptr != NULL) {
+				fprintf(out,"        [CF] type(%d) min: %d max: %d\n", cf_ptr->field_type_unsigned, cf_ptr->min_count, cf_ptr->max_count);
+			}
+			break;
+		case VARIABLE_LENGTH_FIELD_TYPE:
+			vlf_ptr = (variable_length_field_t *)f_ptr->field;
+			fprintf(out,"\n      [%d VLF] %s format: %s (%s)\n", f_count, vlf_ptr->name, vlf_ptr->field_format, (vlf_ptr->optional) ? "optional" : "req");
+			cf_ptr = vlf_ptr->count_field;
+			if (cf_ptr != NULL) {
+				fprintf(out,"        [CF] type(%d) min: %d max: %d\n", cf_ptr->field_type_unsigned, cf_ptr->min_count, cf_ptr->max_count);
+			}
+			break;
+		case VARIABLE_FORMAT_FIELD_TYPE:
+			vff_ptr = (variable_format_field_t *)f_ptr->field;
+			fprintf(out,"\n      [%d VFF] %s (%s)\n", f_count, vff_ptr->name, (vff_ptr->optional) ? "optional" : "req");
+			fe_ptr = vff_ptr->format_enum;
+			while (fe_ptr != NULL) {
+				fprintf(out,"        [FE] index: %d format: %s\n", fe_ptr->index, fe_ptr->field_format);
+				fe_ptr = fe_ptr->next;
+			}
+			cf_ptr = vff_ptr->count_field;
+			if (cf_ptr != NULL) {
+				fprintf(out,"        [CF] type(%d) min: %d max: %d\n", cf_ptr->field_type_unsigned, cf_ptr->min_count, cf_ptr->max_count);
+			}
+			break;
+		default:
+			fprintf(out,"      [%d] Unknown field type %d\n\n",f_count, f_ptr->type);
+	}
+}
+
+void test_print_comp(field_t *f_ptr)
+{
+	field_t *lf_ptr;
+
+	record_t *r_ptr;
+	list_t *l_ptr;
+		count_field_t *cf_ptr;
+	variant_t *v_ptr;
+	sequence_t *s_ptr;
+
+	int f_count = 0;
+
+	switch (f_ptr->type) {
+		case RECORD_TYPE:
+			r_ptr = (record_t *)f_ptr->field;
+			fprintf(out,"\n   [RECORD]: %s (%s) pv = (%d)\n", r_ptr->name,
+				(r_ptr->optional) ? "optional" : "req", r_ptr->presence_vector_type);
+			f_ptr = r_ptr->field;
+			while (f_ptr != NULL) {
+				f_count++;
+				test_print_field(f_ptr, f_count);
+				f_ptr = f_ptr->next;
+			}
+			break;
+		case LIST_TYPE:
+			l_ptr = (list_t *)f_ptr->field;
+			fprintf(out,"\n   [LIST]: %s (%s) \n", l_ptr->name,
+				(l_ptr->optional) ? "optional" : "req");
+			cf_ptr = l_ptr->count_field;
+			fprintf(out,"     [CF]: ft: %d min: %d max: %d\n", cf_ptr->field_type_unsigned, cf_ptr->min_count,
+				cf_ptr->max_count);
+			test_print_comp(l_ptr->field);
+			break;
+		case VARIANT_TYPE:
+			v_ptr = (variant_t *)f_ptr->field;
+			fprintf(out,"\n   [VARIANT]: %s (%s) \n", v_ptr->name,
+				(v_ptr->optional) ? "optional" : "req");
+			fprintf(out,"     [vtag]: ft: %d min: %d max: %d\n", v_ptr->field_type_unsigned, v_ptr->min_count,
+				v_ptr->max_count);
+			lf_ptr = v_ptr->field;
+			while (lf_ptr != NULL) {
+				test_print_comp(lf_ptr);
+				lf_ptr = lf_ptr->next;
+			}
+			break;
+		case SEQUENCE_TYPE:
+			s_ptr = (sequence_t *)f_ptr->field;
+			fprintf(out,"\n   [SEQUENCE]: %s (%s) pv = (%d)\n", s_ptr->name,
+				(s_ptr->optional) ? "optional" : "req", s_ptr->presence_vector_type);
+			lf_ptr = s_ptr->field;
+			while (lf_ptr != NULL) {
+				test_print_comp(lf_ptr);
+				lf_ptr = lf_ptr->next;
+			}
+			break;
+		default:
+			fprintf(out,"   Unknown comp field type %d\n\n", f_ptr->type);
+	}
+}
+
+/**
+ * Called if DEBUG is one for testing reading of tree information
+ *
+ */
+void test_print()
+{
+	message_def_t *m_ptr;
+	field_t *f_ptr;
+
+	int m_count;
+	m_count = 0;
+
+	if (message_set != NULL) {
+		m_ptr = message_set;
+
+		while (m_ptr != NULL) {
+			m_count++;
+			fprintf(out,"\n[%d] %s (0x%04X) is_command: %s\n", m_count, m_ptr->name, m_ptr->message_id,
+				(m_ptr->is_command) ? "yes" : "no");
+
+			f_ptr = m_ptr->body;
+			if (f_ptr != NULL){
+
+				if (DEBUG2) test_print_comp(f_ptr);
+
+			} else if (DEBUG2) fprintf(out,"\tf_ptr is NULL\n");
+			m_ptr = m_ptr->next;
+		}
+
+	} else fprintf(out,"No message_set made!!");
+
+}
+
+/**
+ * Starts the libxml2 xml parser on the files.
+ *    Finds the root element and calls read_message_defs
+ *    Cleans up the xml parser.
+ *
+ */
+void start_xml_parse()
+{
+	xmlDoc *doc = NULL;
+	xmlNode *root_element = NULL;
+	/*
+	Need to be able to read multiple files in a folder of type .xml
+	*/
+#if _WIN32
+	/*
+	This way is for Windows using <windows.h>.
+	 */
+	WIN32_FIND_DATA FindFileData;
+	HANDLE hFind;
+	char filename[MAX_PATH];
+	int path_len;
+	char path_name[200];
+	/*
+	SearchPath returns the full path to wireshark.exe
+	Used to get the path of the wireshark install then used to find location of XMLs
+	*/
+	path_len = SearchPath(NULL,"wireshark.exe",NULL, 200, path_name,NULL);
+	if (!path_len) { return;}
+
+	/* Remove the wireshark.exe from the path */
+	while (path_name[path_len] != '\\') {
+		path_name[path_len] = '\0';
+		path_len--;
+	}
+
+	strncpy(filename, path_name, 150);
+
+	if (DEBUG1) {
+		strncat(filename, "packet-jaus-support/Messages_Found.txt", 200);
+		out = fopen(filename,"w");
+		if(out == NULL) { return;}
+	}
+
+	strncpy(filename, path_name, 150);
+	strncat(filename, "packet-jaus-support/jausxml/*.xml", 200);
+
+	/* Finds first file */
+	hFind = FindFirstFile(filename, &FindFileData);
+	if (hFind != INVALID_HANDLE_VALUE) {
+		do {
+			/* setup filename */
+			strncpy(filename, path_name, 150);
+			strncat(filename,"packet-jaus-support/jausxml/", 50);
+			strncat(filename, FindFileData.cFileName, 200);
+
+			if (DEBUG1) fprintf(out,"-- FILE FOUND \"%s\"\n", filename);
+
+			/* send filename to xml reader */
+			doc = xmlReadFile(filename, NULL, 0);
+
+			if (doc == NULL) {
+				fprintf(out,"error: could not parse file\n");
+			}
+
+			/*Get the root element node */
+			root_element = xmlDocGetRootElement(doc);
+
+
+			if (root_element != NULL) {
+				/* start parse for message_defs on root */
+				read_message_defs(root_element);
+			} else {
+				fprintf(out,"error: empty document\n");
+			}
+
+			/*free the document */
+			xmlFreeDoc(doc);
+
+			/*
+			 *Free the global variables that may
+			 *have been allocated by the parser.
+			 */
+			xmlCleanupParser();
+
+		/* Find Next file using the info for finding the first, 0 = NO_MORE_FILES */
+		} while (FindNextFile(hFind, &FindFileData));
+
+		if (DEBUG1) fprintf(out,"FindFile failed (%s)\n", (GetLastError() == ERROR_NO_MORE_FILES)? "ERROR_NO_MORE_FILES" : "ERROR");
+		FindClose(hFind);
+	}
+
+#else
+
+	/* Use dirent.h */
+	struct dirent *entry;
+	DIR *dp;
+	char filename[256];
+	char path_name[200];
+
+	strncpy(path_name, "/usr/local/lib/wireshark/packet-jaus-support/jausxml/", 60);
+
+	dp = opendir(path_name);
+	if (dp == NULL) {
+		perror("opendir");
+		return;
+	}
+
+	if (DEBUG1) {
+		strncpy(filename, "/usr/local/lib/wireshark/packet-jaus-support/Messages_Found.txt", 70);
+		out = fopen(filename,"w");
+		if(out == NULL) { return;}
+	}
+
+	while((entry = readdir(dp))) {
+		puts(entry->d_name);
+		// skip "." and ".."
+		if (strcmp(".", entry->d_name) == 0 || strcmp("..", entry->d_name) == 0)
+        		continue;
+
+		// if file is .xml, open and try to parse
+		if (strstr(entry->d_name, ".xml") == NULL) {
+			printf(" not .xml: %s, continue.\n", entry->d_name);
+			continue;
+		}
+		
+		strncpy(filename, path_name, 150);
+		strncat(filename, entry->d_name, 200);
+
+		if (DEBUG1) fprintf(out,"-- FILE FOUND \"%s\"\n", filename);
+
+		/* send filename to xml reader */
+		doc = xmlReadFile(filename, NULL, 0);
+
+		if (doc == NULL) {
+			fprintf(out,"error: could not parse file\n\n");
+		}
+
+		/*Get the root element node */
+		root_element = xmlDocGetRootElement(doc);
+
+
+		if (root_element != NULL) {
+			/* start parse for message_defs on root */
+			read_message_defs(root_element);
+		} else {
+			fprintf(out,"error: empty document\n");
+		}
+
+		/*free the document */
+		xmlFreeDoc(doc);
+
+		/*
+		 *Free the global variables that may
+		 *have been allocated by the parser.
+		 */
+		xmlCleanupParser();
+
+	/* Find Next file using the info for finding the first, 0 = NO_MORE_FILES */
+	} 
+
+	closedir(dp);
+#endif
+
+	if (DEBUG1) {
+		test_print();
+		fclose(out);
+	}
+
+
+}
+
+/**
+ * Test jausxml.c
+ *
+ * XML files should be here "packet-jaus-support\jausxml\*.xml"
+ *  
+ * Note2self: this is how to compile this in windows cmd :)
+ *     C:\wireshark-1.4\plugins\jaus>CL -I \libxml2\include jausxml.c \libxml2\lib\libxml2.lib
+ *
+ *  ****This test will no longer work with the addition of the look for wireshark location code.****
+ *                  required to run from the dissector
+ *     Acttualy, if you run this from the the wireshark complied directory, then it will work
+ */
+int main(int argc, char **argv)
+{
+	if (DEBUG) printf("Testing JAUSxml parsing\n\n");
+    
+	start_xml_parse();
+
+	if (DEBUG) printf("\n\nDone Testing JAUSxml parsing\n");
+    return 0;
+}

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/jausxml.h
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/jausxml.h
@@ -1,0 +1,312 @@
+/***********           LICENSE HEADER   *******************************
+JAUS Tool Set
+Copyright (c)  2010, United States Government
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+       Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+       Redistributions in binary form must reproduce the above copyright 
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+
+       Neither the name of the United States Government nor the names of 
+its contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+*********************  END OF LICENSE ***********************************/
+
+#ifndef JAUSXML_H_
+#define JAUSXML_H_
+
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+/* Relax NG notation (jsidl)
+	+ one or more occurrences
+	* zero or more occurrences
+	? optional (zero or one?)
+	  only one occurrence
+ */
+
+#define FLOOR		0
+#define ROUND		1
+#define CEILING		2
+
+#define INCLUSIVE	0
+#define EXCLUSIVE	1
+
+/* Primitive Data Types			bytes/bits */
+#define PDT_BYTE			0	/*  1/8   */
+#define PDT_SHORT_INT		1	/*  2/16  */
+#define PDT_INT				2	/*  4/32  */
+#define PDT_LONG_INT		3	/*  8/64  */
+#define PDT_UBYTE			4	/*  1/8   */
+#define PDT_USHORT_INT		5	/*  2/16  */
+#define PDT_UINT			6	/*  4/32  */
+#define PDT_ULONG_INT		7	/*  8/64  */
+#define PDT_FLOAT			8	/*  4/32  */
+#define PDT_LONG_FLOAT		9	/*  8/64  */
+#define PDT_BAD				10 /* Not Optional but unknown ERROR */
+#define PDT_OP				11 /* Optional */
+
+/* Composite Fields */
+#define ARRAY_TYPE					0
+#define RECORD_TYPE					1
+#define LIST_TYPE					2
+#define VARIANT_TYPE				3
+#define SEQUENCE_TYPE				4
+
+/* Simple Fields */
+#define FIXED_FIELD_TYPE			5
+#define VARIABLE_FIELD_TYPE			6
+#define BIT_FIELD_TYPE				7
+#define FIXED_LENGTH_STRING_TYPE	8
+#define VARIABLE_LENGTH_STRING_TYPE	9
+#define VARIABLE_LENGTH_FIELD_TYPE	10
+#define VARIABLE_FORMAT_FIELD_TYPE	11
+
+typedef struct _field {
+	unsigned char type;
+	void *field;
+	struct _field *next;
+} field_t;
+
+typedef struct record {
+	char name[64];
+	unsigned char optional;
+	/* presence_vector (?) */
+		char presence_vector_type;
+	field_t *field;
+} record_t;
+
+typedef struct count_field {
+	char field_type_unsigned;
+	unsigned int min_count; /* ? */
+	unsigned int max_count; /* ? */
+	char interpretation[64]; /* ? */
+} count_field_t;
+
+typedef struct dimension {
+	char name[64];
+	int size;
+	struct dimension *next;
+} dimension_t;
+
+typedef struct array {
+	char name[64];
+	unsigned char optional;
+	field_t *field;
+	/* dimensions ... */
+		dimension_t *dimension; /* + */
+} array_t;
+
+typedef struct list {
+	char name[64];
+	unsigned char optional;
+	count_field_t *count_field;
+	field_t *field;
+} list_t;
+
+typedef struct variant {
+	char name[64];
+	unsigned char optional;
+	/* vtag_field */
+		char field_type_unsigned;
+		unsigned int min_count; /* ? */
+		unsigned int max_count; /* ? */
+	field_t *field; /* * */
+} variant_t;
+
+typedef struct sequence {
+	char name[64];
+	unsigned char optional;
+	/* presence_vector (?) */
+		char presence_vector_type;
+	field_t *field; /* + */
+} sequence_t;
+
+typedef struct _message_def {
+	unsigned short message_id;
+	char name[64];
+	char is_command;
+	field_t *header;
+	field_t *body;
+	field_t *footer;
+	struct _message_def *next;
+} message_def_t;
+
+typedef struct value_range {
+	int lower_limit;
+	char lower_limit_type;
+	int upper_limit;
+	char upper_limit_type;
+	char interpretation[64];
+	struct value_range *next;
+} value_range_t;
+
+typedef struct value_enum {
+	long enum_index;
+	char enum_const[64];
+	struct value_enum *next;
+} value_enum_t;
+
+typedef struct scale_range {
+	double real_lower_limit;
+	double real_upper_limit;
+	char integer_function;
+} scale_range_t;
+
+typedef struct value_set {
+	unsigned char offset_to_lower_limit;
+	value_range_t *value_range; /* + */
+	value_enum_t *value_enum; /* + */
+} value_set_t;
+
+typedef struct fixed_field {
+	char name[64];
+	char field_type;
+	char field_units[32];
+	unsigned char optional;
+	char interpretation[64]; /* ? */
+	scale_range_t *scale_range; /* ? */
+	value_set_t *value_set; /* ? */
+} fixed_field_t;
+
+typedef struct sub_field {
+	char name[64];
+	/* bit_range (req) */
+		unsigned char from_index;
+		unsigned char to_index;
+	/* value_set (req) */
+		unsigned char offset_to_lower_limit;
+		value_range_t *value_range; /* + */
+		value_enum_t *value_enum; /* + */
+	struct sub_field *next;
+} sub_field_t;
+
+typedef struct bit_field {
+	char name[64];
+	char field_type_unsigned;
+	unsigned char optional;
+	sub_field_t *sub_field; /* + */
+} bit_field_t;
+
+typedef struct type_and_units_enum {
+	unsigned char index;
+	char field_type;
+	char field_units[32];
+	char name[32]; /* ? */
+	value_set_t *value_set; /* ? */
+	scale_range_t *scale_range; /* ? */
+	struct type_and_units_enum *next;
+} type_and_units_enum_t;
+
+typedef struct variable_field {
+	char name[64];
+	unsigned char optional;
+	char interpretation[64]; /* ? */
+	/* type_and_units_field (req) */
+		type_and_units_enum_t *taue; /* + */
+} variable_field_t;
+
+typedef struct fixed_length_string {
+	char name[64];
+	unsigned int string_length;
+	unsigned char optional;
+	char interpretation[64]; /* ? */
+} fixed_length_string_t;
+
+typedef struct variable_length_string {
+	char name[64];
+	unsigned char optional;
+	char interpretation[64]; /* ? */
+	count_field_t *count_field;
+} variable_length_string_t;
+
+typedef struct variable_length_field {
+	char name[64];
+	char field_format[15];
+	unsigned char optional;
+	char interpretation[64]; /* ? */
+	count_field_t *count_field;
+} variable_length_field_t;
+
+typedef struct format_enum {
+	unsigned char index;
+	char field_format[15];
+	struct format_enum *next;
+} format_enum_t;
+
+typedef struct variable_format_field {
+	char name[64];
+	unsigned char optional;
+	char interpretation[64]; /* ? */
+	/* format_field (req) */
+		format_enum_t *format_enum; /* + */
+	count_field_t *count_field;
+} variable_format_field_t;
+
+typedef struct vtag_field {
+	char field_type_unsigned[24];
+	unsigned int min_count; /* ? */
+	unsigned int max_count; /* ? */
+} vtag_field_t;
+
+
+
+/* forward references */
+message_def_t *add_message_def(char *name, unsigned short message_id, unsigned char is_command);
+void *add_field(field_t **field, unsigned char field_type);
+
+void parse_message_def(xmlNode *message_node);
+/* Composite Fields */
+void parse_jaus_record(xmlNode *record_node, record_t *record);
+void parse_array(xmlNode *a_node, array_t *array);
+void parse_list(xmlNode *l_node, list_t *list);
+void parse_variant(xmlNode *v_node, variant_t *variant);
+void parse_sequence(xmlNode *s_node, sequence_t *sequence);
+/* Simple Fields */
+void parse_fixed_field(xmlNode *ff_node, fixed_field_t *fixed_field);
+void parse_bit_field(xmlNode *bf_node, bit_field_t *bit_field);
+void parse_variable_field(xmlNode *vf_node, variable_field_t *variable_field);
+void parse_fixed_length_string(xmlNode *fls_node, fixed_length_string_t *fixed_length_string);
+void parse_variable_length_string(xmlNode *vls_node, variable_length_string_t *variable_length_string);
+void parse_variable_length_field(xmlNode *vlf_node, variable_length_field_t *variable_length_field);
+void parse_variable_format_field(xmlNode *vff_node, variable_format_field_t *variable_format_field);
+/* Meta Fields */
+void parse_presence_vector(xmlNode *pv_node, record_t *record);
+void parse_count_field(xmlNode *cf_node, count_field_t *count_field);
+/* Field Information */
+void parse_dimension(xmlNode *d_node, dimension_t *dimension);
+void parse_scale_range(xmlNode *sr_node, scale_range_t *field_ptr);
+void parse_sub_field(xmlNode * sf_node, sub_field_t *sub_field);
+void parse_value_range(xmlNode *vr_node, value_range_t *value_range);
+void parse_value_enum(xmlNode *next_node, value_enum_t *value_enum);
+void parse_value_set(xmlNode *next_node, value_set_t *value_set);
+void parse_type_and_units_enum(xmlNode *taue_node, type_and_units_enum_t *taue);
+void parse_format_enum(xmlNode *fe_node, format_enum_t *format_enum);
+
+char get_field_type(char* type);
+static const xmlChar* get_attr_name(xmlAttr *);
+static const xmlChar* get_attr_value(xmlAttr *);
+xmlNode *find_child_node(xmlNode * a_node, char *name);
+void read_message_defs(xmlNode * a_node);
+void start_xml_parse();
+
+
+#endif /*JAUSXML_H_*/

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/make-plugin-reg.py
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/make-plugin-reg.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+#
+# Looks for registration routines in the plugins
+# and assembles C code to call all the routines.
+# A new "plugin.c" file will be written in the current directory.
+#
+
+import os
+import sys
+import re
+
+#
+# The first argument is the directory in which the source files live.
+#
+srcdir = sys.argv[1]
+#
+# The second argument is either "plugin", "plugin_wtap", "plugin_codec",
+# or "plugin_tap".
+#
+registertype = sys.argv[2]
+#
+# All subsequent arguments are the files to scan.
+#
+files = sys.argv[3:]
+
+final_filename = "plugin.c"
+preamble = """\
+/*
+ * Do not modify this file. Changes will be overwritten.
+ *
+ * Generated automatically from %s.
+ */
+""" % (os.path.basename(sys.argv[0]))
+
+# Create the proper list of filenames
+filenames = []
+for file in files:
+    if os.path.isfile(file):
+        filenames.append(file)
+    else:
+        filenames.append(os.path.join(srcdir, file))
+
+if len(filenames) < 1:
+    print("No files found")
+    sys.exit(1)
+
+
+# Look through all files, applying the regex to each line.
+# If the pattern matches, save the "symbol" section to the
+# appropriate set.
+regs = {
+        'proto_reg': set(),
+        'handoff_reg': set(),
+        'wtap_register': set(),
+        'codec_register': set(),
+        'register_tap_listener': set(),
+        }
+
+# For those that don't know Python, r"" indicates a raw string,
+# devoid of Python escapes.
+proto_regex = r"\bproto_register_(?P<symbol>[\w]+)\s*\(\s*void\s*\)\s*{"
+
+handoff_regex = r"\bproto_reg_handoff_(?P<symbol>[\w]+)\s*\(\s*void\s*\)\s*{"
+
+wtap_reg_regex = r"\bwtap_register_(?P<symbol>[\w]+)\s*\(\s*void\s*\)\s*{"
+
+codec_reg_regex = r"\bcodec_register_(?P<symbol>[\w]+)\s*\(\s*void\s*\)\s*{"
+
+tap_reg_regex = r"\bregister_tap_listener_(?P<symbol>[\w]+)\s*\(\s*void\s*\)\s*{"
+
+# This table drives the pattern-matching and symbol-harvesting
+patterns = [
+        ( 'proto_reg', re.compile(proto_regex, re.MULTILINE | re.ASCII) ),
+        ( 'handoff_reg', re.compile(handoff_regex, re.MULTILINE | re.ASCII) ),
+        ( 'wtap_register', re.compile(wtap_reg_regex, re.MULTILINE | re.ASCII) ),
+        ( 'codec_register', re.compile(codec_reg_regex, re.MULTILINE | re.ASCII) ),
+        ( 'register_tap_listener', re.compile(tap_reg_regex, re.MULTILINE | re.ASCII) ),
+        ]
+
+# Grep
+for filename in filenames:
+    file = open(filename)
+    # Read the whole file into memory
+    contents = file.read()
+    for action in patterns:
+        regex = action[1]
+        for match in regex.finditer(contents):
+            symbol = match.group("symbol")
+            sym_type = action[0]
+            regs[sym_type].add(symbol)
+    # We're done with the file contents
+    del contents
+    file.close()
+
+# Make sure we actually processed something
+if (len(regs['proto_reg']) < 1 and len(regs['wtap_register']) < 1 and len(regs['codec_register']) < 1 and len(regs['register_tap_listener']) < 1):
+    print("No plugin registrations found")
+    sys.exit(1)
+
+# Convert the sets into sorted lists to make the output pretty
+regs['proto_reg'] = sorted(regs['proto_reg'])
+regs['handoff_reg'] = sorted(regs['handoff_reg'])
+regs['wtap_register'] = sorted(regs['wtap_register'])
+regs['codec_register'] = sorted(regs['codec_register'])
+regs['register_tap_listener'] = sorted(regs['register_tap_listener'])
+
+reg_code = ""
+
+reg_code += preamble
+
+reg_code += """
+#include "config.h"
+
+#include <gmodule.h>
+
+/* plugins are DLLs on Windows */
+#define WS_BUILD_DLL
+#include "ws_symbol_export.h"
+#include <wsutil/plugins.h>
+
+"""
+
+if registertype == "plugin":
+    reg_code += "#include \"epan/proto.h\"\n\n"
+if registertype == "plugin_wtap":
+    reg_code += "#include \"wiretap/wtap.h\"\n\n"
+if registertype == "plugin_codec":
+    reg_code += "#include \"wsutil/codecs.h\"\n\n"
+if registertype == "plugin_tap":
+    reg_code += "#include \"epan/tap.h\"\n\n"
+
+for symbol in regs['proto_reg']:
+    reg_code += "void proto_register_%s(void);\n" % (symbol)
+for symbol in regs['handoff_reg']:
+    reg_code += "void proto_reg_handoff_%s(void);\n" % (symbol)
+for symbol in regs['wtap_register']:
+    reg_code += "void wtap_register_%s(void);\n" % (symbol)
+for symbol in regs['codec_register']:
+    reg_code += "void codec_register_%s(void);\n" % (symbol)
+for symbol in regs['register_tap_listener']:
+    reg_code += "void register_tap_listener_%s(void);\n" % (symbol)
+
+DESCRIPTION_FLAG = {
+    'plugin': 'WS_PLUGIN_DESC_DISSECTOR',
+    'plugin_wtap': 'WS_PLUGIN_DESC_FILE_TYPE',
+    'plugin_codec': 'WS_PLUGIN_DESC_CODEC',
+    'plugin_tap': 'WS_PLUGIN_DESC_TAP_LISTENER'
+}
+
+reg_code += """
+WS_DLL_PUBLIC_DEF const char plugin_version[] = PLUGIN_VERSION;
+WS_DLL_PUBLIC_DEF const int plugin_want_major = VERSION_MAJOR;
+WS_DLL_PUBLIC_DEF const int plugin_want_minor = VERSION_MINOR;
+
+WS_DLL_PUBLIC void plugin_register(void);
+WS_DLL_PUBLIC uint32_t plugin_describe(void);
+
+uint32_t plugin_describe(void)
+{
+    return %s;
+}
+
+void plugin_register(void)
+{
+""" % DESCRIPTION_FLAG[registertype]
+
+if registertype == "plugin":
+    for symbol in regs['proto_reg']:
+        reg_code +="    static proto_plugin plug_%s;\n\n" % (symbol)
+        reg_code +="    plug_%s.register_protoinfo = proto_register_%s;\n" % (symbol, symbol)
+        if symbol in regs['handoff_reg']:
+            reg_code +="    plug_%s.register_handoff = proto_reg_handoff_%s;\n" % (symbol, symbol)
+        else:
+            reg_code +="    plug_%s.register_handoff = NULL;\n" % (symbol)
+        reg_code += "    proto_register_plugin(&plug_%s);\n" % (symbol)
+if registertype == "plugin_wtap":
+    for symbol in regs['wtap_register']:
+        reg_code += "    static wtap_plugin plug_%s;\n\n" % (symbol)
+        reg_code += "    plug_%s.register_wtap_module = wtap_register_%s;\n" % (symbol, symbol)
+        reg_code += "    wtap_register_plugin(&plug_%s);\n" % (symbol)
+if registertype == "plugin_codec":
+    for symbol in regs['codec_register']:
+        reg_code += "    static codecs_plugin plug_%s;\n\n" % (symbol)
+        reg_code += "    plug_%s.register_codec_module = codec_register_%s;\n" % (symbol, symbol)
+        reg_code += "    codecs_register_plugin(&plug_%s);\n" % (symbol)
+if registertype == "plugin_tap":
+    for symbol in regs['register_tap_listener']:
+        reg_code += "    static tap_plugin plug_%s;\n\n" % (symbol)
+        reg_code += "    plug_%s.register_tap_listener = register_tap_listener_%s;\n" % (symbol, symbol)
+        reg_code += "    tap_register_plugin(&plug_%s);\n" % (symbol)
+
+reg_code += "}\n"
+
+try:
+    fh = open(final_filename, 'w')
+    fh.write(reg_code)
+    fh.close()
+except OSError:
+    sys.exit('Unable to write ' + final_filename + '.\n')
+
+#
+# Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+#
+# Local variables:
+# c-basic-offset: 4
+# indent-tabs-mode: nil
+# End:
+#
+# vi: set shiftwidth=4 expandtab:
+# :indentSize=4:noTabs=true:
+#

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/packet-jaus.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/packet-jaus.c
@@ -545,7 +545,7 @@ dissect_jaus(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *data)
 	guint8 version = 0;
 
 	/* get the first byte to check for the version of jaus message */
-	version = tvb_get_guint8( tvb, 0 );
+	version = tvb_get_uint8( tvb, 0 );
 
 	if (version == 'J') { /* Legacy Header RA3 */
 		return dissect_RA3_header(tvb, pinfo, tree);
@@ -606,7 +606,7 @@ int dissect_sdp_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
 
 	}
 
-	hc = tvb_get_guint8( tvb, offset );
+	hc = tvb_get_uint8( tvb, offset );
 
 	if ((hc & HC_FLAG) != 0) {
 		compression = 1;
@@ -661,14 +661,14 @@ int dissect_sdp_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
 
 	if (compression) {
 
-		hc_num = tvb_get_guint8(tvb, offset);
+		hc_num = tvb_get_uint8(tvb, offset);
 		if (tree) {
 			/* add hc_mun to header tree */
 			proto_tree_add_item(jaus_header_tree, hf_jaus_hc_num, tvb, offset, 1, ENC_LITTLE_ENDIAN);
 		}
 		offset+=1;
 
-		hc_length = tvb_get_guint8(tvb, offset);
+		hc_length = tvb_get_uint8(tvb, offset);
 		if (tree) {
 			/* add hc_length to header tree */
 			proto_tree_add_item(jaus_header_tree, hf_jaus_hc_lenght, tvb, offset, 1, ENC_LITTLE_ENDIAN);
@@ -679,7 +679,7 @@ int dissect_sdp_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
 
 	if (!compression) {
 
-		properties = tvb_get_guint8(tvb, offset);
+		properties = tvb_get_uint8(tvb, offset);
 		const guint8 data_flag = ( properties >> 6 ) & 0x3;
 
 		if (tree) {
@@ -841,7 +841,7 @@ int dissect_RA3_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
 
 	m_ptr = get_message_def(command);
 
-	properties = tvb_get_guint8(tvb, offset);
+	properties = tvb_get_uint8(tvb, offset);
 
 	if (check_col(pinfo->cinfo, COL_INFO)) {
 		col_add_fstr(pinfo->cinfo, COL_INFO, "Cmd(0x%04X) %s  %s  [priority %d]", command, (m_ptr)?m_ptr->name:" --- ",
@@ -1394,7 +1394,7 @@ int dissect_variable_format_field(tvbuff_t *tvb, proto_tree *tree, variable_form
 	fe_ptr = vff_ptr->format_enum;
 	cf_ptr = vff_ptr->count_field;
 
-	const guint8 field_enum = tvb_get_guint8(tvb, offset);
+	const guint8 field_enum = tvb_get_uint8(tvb, offset);
 	offset += 1;
 
 	/* Find matching format_enum to data(index) pulled from buffer */
@@ -1831,7 +1831,7 @@ int get_data_from_tvb(tvbuff_t *tvb, int offset, char type, int size, guint64 *d
 	}
 
 	if (type == PDT_BYTE || type == PDT_UBYTE)
-		*data = (guint64)tvb_get_guint8(tvb, offset);
+		*data = (guint64)tvb_get_uint8(tvb, offset);
 	else if (type == PDT_SHORT_INT || type == PDT_USHORT_INT)
 		*data = (guint64)tvb_get_letohs(tvb, offset);/* Little-Endian-to-host-order accessors */
 	else if (type == PDT_INT || type == PDT_UINT || type == PDT_FLOAT)
@@ -1868,8 +1868,8 @@ double scale_convert(unsigned int scaled_value, int bits, double real_lower, dou
  */
 int get_sdp_id_from_tvb(tvbuff_t *tvb, int offset, char* jaus_id)
 {
-	const int comp = tvb_get_guint8(tvb , offset);
-	const int node = tvb_get_guint8(tvb , offset+1);
+	const int comp = tvb_get_uint8(tvb , offset);
+	const int node = tvb_get_uint8(tvb , offset+1);
 	const int subs = tvb_get_letohs(tvb , offset+2);
 	return sprintf(jaus_id, "%d.%d.%d", subs, node, comp);
 }
@@ -1881,10 +1881,10 @@ int get_sdp_id_from_tvb(tvbuff_t *tvb, int offset, char* jaus_id)
  */
 int get_ra3_id_from_tvb(tvbuff_t *tvb, int offset, char* jaus_id)
 {
-	const int inst = tvb_get_guint8(tvb , offset);
-	const int comp = tvb_get_guint8(tvb , offset+1);
-	const int node = tvb_get_guint8(tvb , offset+2);
-	const int subs = tvb_get_guint8(tvb , offset+3);
+	const int inst = tvb_get_uint8(tvb , offset);
+	const int comp = tvb_get_uint8(tvb , offset+1);
+	const int node = tvb_get_uint8(tvb , offset+2);
+	const int subs = tvb_get_uint8(tvb , offset+3);
 	return sprintf(jaus_id, "%d.%d.%d.%d", subs, node, comp, inst);
 }
 

--- a/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/packet-jaus.c
+++ b/wiresharkPlugin/packet-jaus/src/Wireshark-4.6.x/packet-jaus.c
@@ -1,0 +1,1934 @@
+/***********           LICENSE HEADER   *******************************
+JAUS Tool Set
+Copyright (c)  2010, 2022 United States Government
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+       Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+       Redistributions in binary form must reproduce the above copyright 
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+
+       Neither the name of the United States Government nor the names of 
+its contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+*********************  END OF LICENSE ***********************************/
+
+/* packet-jaus.c
+ * Routines for Joint Architecture for Unmanned Systems (JAUS) dissection.
+ * Copyright 2008, Alex Evans <alex_evans@wintec-inc.com>
+ * Updated 2022, Dave Martin <dmartin@neyarobotics.com>
+ *
+ * Wireshark - Network traffic analyzer
+ * By Gerald Combs <gerald@wireshark.org>
+ * Copyright 1998 Gerald Combs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <math.h>
+#include "jausxml.h"
+#include <epan/packet.h>
+#include <epan/reassemble.h>
+#include <epan/tvbuff.h>
+
+#define PROTO_TAG_JAUS       "JAUS"
+#define JAUS_START_STRING    "JAUS01.0"
+
+/* Minimum JAUS message length.
+   16 Bytes (header) + 8 Bytes(JAUS01.0) */
+#define JAUS_MIN_LEN     24
+
+/* Message Properties flags */
+#define JAUS_PRIORITY_FLAG       0x0F
+#define JAUS_ACKNAK_FLAG         0x30
+#define JAUS_SERVICE_FLAG        0x40
+#define JAUS_EXPERIMENTAL_FLAG   0x80
+#define JAUS_VERSION_FLAG        0x3F
+
+#define MSG_TYPE_FLAG  0x3F
+#define HC_FLAG        0xC0
+#define PRIORITY_FLAG  0x03
+#define BCAST_FLAG     0x0C
+#define ACK_NAK_FLAG   0x30
+#define DATA_FLAG      0xC0
+
+/* message_set found in jausxml.c */
+extern message_def_t *message_set;
+
+/* global offset for data dissection */
+int data_offset;
+
+/* forward references */
+void proto_register_jaus(void);
+void proto_reg_handoff_jaus(void);
+static int dissect_jaus(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *data);
+int dissect_RA3_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree);
+int dissect_sdp_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree);
+int dissect_message_field(tvbuff_t *tvb, proto_tree *tree, field_t *f_ptr, int _op_count, guint64 presence_vector);
+int dissect_message_data(tvbuff_t *tvb, proto_tree *tree, int _offset, message_def_t *m_ptr);
+int dissect_packet_data(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, int offset, int reserve_bytes);
+int dissect_embedded_message_data(tvbuff_t *tvb, proto_tree *tree, int offset);
+int get_number_of_bytes(char type);
+int get_data_from_tvb(tvbuff_t *tvb, int offset, char type, int size, guint64 *data);
+double scale_convert(unsigned int scaled_value, int bits, double real_lower, double real_upper, char int_function);
+int get_sdp_id_from_tvb(tvbuff_t *tvb, int offset, char* jaus_id);
+int get_ra3_id_from_tvb(tvbuff_t *tvb, int offset, char* jaus_id);
+char* decode_field_type(char type);
+message_def_t* get_message_def(guint16 command);
+
+/* Wireshark ID of the JAUS protocol */
+static int proto_jaus = -1;
+
+/* JAUS protocol port
+   From IANA port list
+   jaus            3794/tcp   JAUS Robots
+   jaus            3794/udp   JAUS Robots */
+static guint global_jaus_port = 3794;
+static guint global_jaus_extra_port = 55555; // An extra port to snoop on
+
+/* These is the handle of the sub-dissector */
+//static dissector_handle_t jaus_handle;
+
+/* some optional text strings representing packet types */
+static const range_string priority_flag[] = {
+	{ 0, 5, "Low Normal" },
+	{ 6, 6, "Default Normal" },
+	{ 7, 11, "High Normal" },
+	{ 12, 15, "Safety Critical" },
+	{ 0, 0, NULL }
+};
+
+static const value_string acknak_flag[] = {
+	{ 0, "None" },
+	{ 1, "Request AckNak" },
+	{ 2, "Nak Response" },
+	{ 3, "Ack Response" },
+	{ 0, NULL }
+};
+
+static const value_string service_flag[] = {
+	{ 0, "None" },
+	{ 1, "Service Connection" },
+	{ 0, NULL }
+};
+
+static const value_string experimental_flag[] = {
+	{ 0, "Jaus" },
+	{ 1, "Experimental" },
+	{ 0, NULL }
+};
+
+static const value_string version_flag[] = {
+	{ 0, "Version 2.0" },
+	{ 1, "Version 3.0 or 3.1" },
+	{ 2, "Version 3.2 or 3.3" },
+	{ 0, NULL }
+};
+
+static const value_string data_flag_vals[] = {
+	{ 0, "None" },
+	{ 1, "First Msg" },
+	{ 2, "Middle Msg" },
+	{ 3, "Last Msg" },
+	{ 0, NULL }
+};
+
+/* These are the ids of the header fields that may be created */
+/* RA3 header */
+static gint hf_jaus_priority = -1;
+static gint hf_jaus_acknak = -1;
+static gint hf_jaus_service = -1;
+static gint hf_jaus_experimental = -1;
+static gint hf_jaus_version = -1;
+static gint hf_jaus_commandCode = -1;
+static gint hf_jaus_destination = -1;
+static gint hf_jaus_dest_sub = -1;
+static gint hf_jaus_dest_node = -1;
+static gint hf_jaus_dest_comp = -1;
+static gint hf_jaus_dest_inst = -1;
+static gint hf_jaus_source = -1;
+static gint hf_jaus_src_sub = -1;
+static gint hf_jaus_src_node = -1;
+static gint hf_jaus_src_comp = -1;
+static gint hf_jaus_src_inst = -1;
+static gint hf_jaus_dataControl = -1;
+static gint hf_jaus_data_size = -1;
+static gint hf_jaus_data_flag = -1;
+static gint hf_jaus_sequenceNumber = -1;
+static gint hf_jaus_data = -1;
+/* SAE new header */
+static gint hf_jaus_message_type = -1;
+static gint hf_jaus_hc = -1;
+static gint hf_jaus_data_size2 = -1;
+static gint hf_jaus_hc_num = -1;
+static gint hf_jaus_hc_lenght = -1;
+static gint hf_jaus_priority2 = -1;
+static gint hf_jaus_acknak2 = -1;
+static gint hf_jaus_bcast = -1;
+static gint hf_jaus_data_flag2 = -1;
+/* universal header for all the unknown number of Fields in the Data */
+static gint hf_jaus_uint64 = -1;
+/* universal header for all the none data fields */
+static gint hf_jaus_none = -1;
+// Support for fragmented messages
+static int hf_jaus_fragments = -1;
+static int hf_jaus_fragment = -1;
+static int hf_jaus_fragment_overlap = -1;
+static int hf_jaus_fragment_overlap_conflict = -1;
+static int hf_jaus_fragment_multiple_tails = -1;
+static int hf_jaus_fragment_too_long_fragment = -1;
+static int hf_jaus_fragment_error = -1;
+static int hf_jaus_fragment_count = -1;
+static int hf_jaus_reassembled_in = -1;
+static int hf_jaus_reassembled_length = -1;
+static int hf_jaus_reassembled_data = -1;
+
+
+/* These are the ids of the subtrees that we may be creating
+ * Used by Wireshark to remember open/closed trees between selected packets
+ */
+static gint ett_jaus = -1;
+static gint ett_jaus_header = -1;
+static gint ett_jaus_message_properties = -1;
+static gint ett_jaus_destination = -1;
+static gint ett_jaus_source = -1;
+static gint ett_jaus_dataControl = -1;
+static gint ett_jaus_data = -1;
+static gint ett_array = -1;
+// Support for fragmented messages
+static gint ett_jaus_fragment = -1;
+static gint ett_jaus_fragments = -1;
+
+static reassembly_table jaus_reassembly_table;
+static const fragment_items jaus_frag_items = {
+	/* Fragment subtrees */
+	&ett_jaus_fragment,
+	&ett_jaus_fragments,
+	/* Fragment fields */
+	&hf_jaus_fragments,
+	&hf_jaus_fragment,
+	&hf_jaus_fragment_overlap,
+	&hf_jaus_fragment_overlap_conflict,
+	&hf_jaus_fragment_multiple_tails,
+	&hf_jaus_fragment_too_long_fragment,
+	&hf_jaus_fragment_error,
+	&hf_jaus_fragment_count,
+	/* Reassembled in field */
+	&hf_jaus_reassembled_in,
+	/* Reassembled length field */
+	&hf_jaus_reassembled_length,
+	&hf_jaus_reassembled_data,
+	/* Tag */
+	"JAUS fragments"};
+
+// Adjust to Wireshark API changes
+#define tvb_length tvb_captured_length
+#define tvb_length_remaining tvb_captured_length_remaining
+#define ep_tvb_memdup(x,y,z) tvb_memdup(NULL,x,y,z)
+#define proto_tree_add_text(a,b,c,d,e...) proto_tree_add_none_format(a,hf_jaus_none,b,c,d,e)
+#define check_col(x, y) TRUE
+#define plurality(x, yes, no) (bytes == 1 ? yes : no)
+#define tvb_get_ephemeral_string(x,y,z) tvb_get_string_enc(NULL, x, y, z,  ENC_UTF_8)
+
+/**
+ * Register the protocol with Wireshark
+ * Called one time
+ */
+void proto_register_jaus(void)
+{
+	/* A header field is something you can search/filter on.
+	 *
+	 * Create a structure to register our fields. It consists of an
+	 * array of hf_register_info structures, each of which are of the format
+	 * {&(field_id),
+	 * {name, abbrev, type, display,
+	 * strings, bitmask, blurb, HFILL}
+	 * },
+	 */
+	static hf_register_info hf[] = {
+
+		{ &hf_jaus_priority,
+		{ "Priority", "jaus.priority", FT_UINT8, BASE_DEC|BASE_RANGE_STRING,
+			RVALS(priority_flag), JAUS_PRIORITY_FLAG, "Priority", HFILL }
+		},
+		{ &hf_jaus_acknak,
+		{ "ack/nak", "jaus.acknak", FT_UINT8, BASE_DEC,
+			VALS(acknak_flag), JAUS_ACKNAK_FLAG, "ack/nak", HFILL }
+		},
+		{ &hf_jaus_service,
+		{ "Service", "jaus.service", FT_UINT8, BASE_DEC,
+			VALS(service_flag), JAUS_SERVICE_FLAG, "Service", HFILL }
+		},
+		{ &hf_jaus_experimental,
+		{ "Experimental?", "jaus.experimental", FT_UINT8, BASE_DEC,
+			VALS(experimental_flag), JAUS_EXPERIMENTAL_FLAG, "Experimental?", HFILL }
+		},
+		{ &hf_jaus_version,
+		{ "Version", "jaus.version", FT_UINT8, BASE_DEC,
+			VALS(version_flag), JAUS_VERSION_FLAG, "Version", HFILL }
+		},
+		{ &hf_jaus_commandCode,
+		{ "Command Code", "jaus.command", FT_UINT16, BASE_HEX,
+			NULL, 0x0, "Command", HFILL }
+		},
+		{ &hf_jaus_destination,
+		{ "Destination ID", "jaus.dest", FT_STRING, BASE_NONE,
+			NULL, 0x0, "Destination", HFILL }
+		},
+		{ &hf_jaus_dest_sub,
+		{ "Subsystem ID", "jaus.dest.sub", FT_UINT32, BASE_DEC,
+			NULL, 0xFF000000, "Destination Subsystem", HFILL }
+		},
+		{ &hf_jaus_dest_node,
+		{ "Node ID", "jaus.dest.node", FT_UINT32, BASE_DEC,
+			NULL, 0x00FF0000, "Destination Node", HFILL }
+		},
+		{ &hf_jaus_dest_comp,
+		{ "Component ID", "jaus.dest.comp", FT_UINT32, BASE_DEC,
+			NULL, 0x0000FF00, "Destination Component", HFILL }
+		},
+		{ &hf_jaus_dest_inst,
+		{ "Instance ID", "jaus.dest.inst", FT_UINT32, BASE_DEC,
+			NULL, 0x000000FF, "Destination Instance", HFILL }
+		},
+		{ &hf_jaus_source,
+		{ "Source ID", "jaus.source", FT_STRING, BASE_NONE,
+			NULL, 0x0, "Source", HFILL }
+		},
+		{ &hf_jaus_src_sub,
+		{ "Subsystem ID", "jaus.src.sub", FT_UINT32, BASE_DEC,
+			NULL, 0xFF000000, "Source Subsystem", HFILL }
+		},
+		{ &hf_jaus_src_node,
+		{ "Node ID", "jaus.src.node", FT_UINT32, BASE_DEC,
+			NULL, 0x00FF0000, "Source Node", HFILL }
+		},
+		{ &hf_jaus_src_comp,
+		{ "Component ID", "jaus.src.comp", FT_UINT32, BASE_DEC,
+			NULL, 0x0000FF00, "Source Component", HFILL }
+		},
+		{ &hf_jaus_src_inst,
+		{ "Instance ID", "jaus.src.inst", FT_UINT32, BASE_DEC,
+			NULL, 0x000000FF, "Source Instance", HFILL }
+		},
+		{ &hf_jaus_dataControl,
+		{ "Data Control", "jaus.dataControl", FT_UINT16, BASE_HEX,
+			NULL, 0x0, "Data Control", HFILL }
+		},
+		{ &hf_jaus_data_size,
+		{ "Data Size", "jaus.dataC.size", FT_UINT16, BASE_DEC,
+			NULL, 0x0FFF, "Data Size", HFILL }
+		},
+		{ &hf_jaus_data_flag,
+		{ "Data Flag", "jaus.dataC.flag", FT_UINT16, BASE_HEX,
+			NULL, 0xF000, "Data Flag", HFILL }
+		},
+		{ &hf_jaus_sequenceNumber,
+		{ "Sequence Number", "jaus.sequenceNumber", FT_UINT16, BASE_DEC,
+			NULL, 0x0, "Sequence Number", HFILL }
+		},
+		{ &hf_jaus_data,
+		{ "Data", "jaus.data", FT_BYTES, BASE_NONE,
+			NULL, 0x0, "data", HFILL }
+		},
+
+		/* New Header */
+		{ &hf_jaus_message_type,
+			{ "Message Type", "jaus.messagetype", FT_UINT8, BASE_DEC,
+			NULL, MSG_TYPE_FLAG, "Message Type", HFILL }
+		},
+		{ &hf_jaus_hc,
+			{ "Header Compression", "jaus.hc", FT_UINT8, BASE_DEC,
+			NULL, HC_FLAG, "Using Header Compression", HFILL }
+		},
+		{ &hf_jaus_data_size2,
+		{ "Data Size", "jaus.datasize", FT_UINT16, BASE_DEC,
+			NULL, 0x0, "Size of message", HFILL }
+		},
+		{ &hf_jaus_hc_num,
+		{ "HC Number", "jaus.hc.num", FT_UINT8, BASE_DEC,
+			NULL, 0x0, "Header Compression Number", HFILL }
+		},
+		{ &hf_jaus_hc_lenght,
+		{ "HC Lenght", "jaus.hc.lenght", FT_UINT8, BASE_DEC,
+			NULL, HC_FLAG, "Header Compression Lenght", HFILL }
+		},
+		{ &hf_jaus_priority2,
+		{ "Priority", "jaus.priority", FT_UINT8, BASE_DEC,
+			NULL, PRIORITY_FLAG, "Priority", HFILL }
+		},
+		{ &hf_jaus_acknak2,
+		{ "ack/nak", "jaus.acknak", FT_UINT8, BASE_DEC,
+			VALS(acknak_flag), ACK_NAK_FLAG, "ack/nak", HFILL }
+		},
+		{ &hf_jaus_bcast,
+		{ "Broadcast", "jaus.bcast", FT_UINT8, BASE_DEC,
+			NULL, BCAST_FLAG, "Broadcast", HFILL }
+		},
+		{ &hf_jaus_data_flag2,
+		{ "Data Flag", "jaus.dataflag", FT_UINT8, BASE_DEC,
+			VALS(data_flag_vals), DATA_FLAG, "Data Flag", HFILL }
+		},
+
+		{ &hf_jaus_uint64,
+		{ "jaus data", "jaus.data", FT_UINT64, BASE_HEX,
+			NULL, 0x0, "jaus payload data", HFILL }
+		},
+		{ &hf_jaus_none,
+		{ "jaus none", "jaus.none", FT_NONE, BASE_NONE,
+			NULL, 0x0, "jaus catch all", HFILL }
+		},
+
+		/* Fragmentation Support */
+		{&hf_jaus_fragments,
+		{"Message fragments", "jaus.fragments", FT_NONE, BASE_NONE,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_fragment,
+		{"Message fragment", "jaus.fragment", FT_FRAMENUM, BASE_NONE,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_fragment_overlap,
+		{"Message fragment overlap", "jaus.fragment.overlap",  FT_BOOLEAN, 0,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_fragment_overlap_conflict,
+		{"Message fragment overlapping with conflicting data", "jaus.fragment.overlap.conflict", FT_BOOLEAN, 0,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_fragment_multiple_tails,
+		{"Message has multiple tail fragments", "jaus.fragment.multiple_tails", FT_BOOLEAN, 0,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_fragment_too_long_fragment,
+		{"Message fragment too long", "jaus.fragment.too_long_fragment", FT_BOOLEAN, 0,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_fragment_error,
+		{"Message defragmentation error", "jaus.fragment.error", FT_FRAMENUM, BASE_NONE,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_fragment_count,
+		{"Message fragment count", "jaus.fragment.count", FT_UINT32, BASE_DEC,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_reassembled_in,
+		{"Reassembled in", "jaus.reassembled.in", FT_FRAMENUM, BASE_NONE,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_reassembled_length,
+		{"Reassembled length", "jaus.reassembled.length", FT_UINT32, BASE_DEC,
+			NULL, 0x00, NULL, HFILL }
+		},
+		{&hf_jaus_reassembled_data,
+		{"Reassembled data", "jaus.reassembled.data", FT_BYTES, BASE_NONE,
+			NULL, 0x00, "reassembled data", HFILL }
+		}
+
+	};
+
+	/* Setup protocol subtree array */
+	static gint *ett[] = {
+		&ett_jaus,
+		&ett_jaus_header,
+		&ett_jaus_message_properties,
+		&ett_jaus_destination,
+		&ett_jaus_source,
+		&ett_jaus_dataControl,
+		&ett_jaus_data,
+		&ett_array,
+		&ett_jaus_fragment,
+		&ett_jaus_fragments
+	};
+
+	module_t *jaus_module = NULL;
+
+	/* Register the protocol name and description */
+	proto_jaus = proto_register_protocol (
+		"JAUS Robots",	/* name */
+		"JAUS",			/* short name */
+		"jaus"			/* abbrev */
+	);
+	
+	/* module Preferences */
+    jaus_module = prefs_register_protocol(proto_jaus, proto_reg_handoff_jaus);
+	
+	/* Allow the user to set the UDP port for the decode under the Edit -> Preferences menu */
+	prefs_register_uint_preference(jaus_module, "tcp.port", "JAUS Port (default 3794)",
+		"Set the port for JAUS TCP/UDP (default 3794)",
+		10, &global_jaus_port);
+	
+	prefs_register_uint_preference(jaus_module, "udp.port", "JAUS Debug intra-node UDP Port",
+		"Using the JR nodeManager, intra-node traffic may be set to output on a different Port",
+		10, &global_jaus_extra_port);
+	
+	/* Required function calls to register the header fields and subtrees used */
+	proto_register_field_array (proto_jaus, hf, array_length(hf));
+	proto_register_subtree_array (ett, array_length(ett));
+	//register_dissector("jaus", dissect_jaus, proto_jaus); /* OLD */
+	
+	/* called in jausxml.c to parse the xml on start-up of wireshark */
+	start_xml_parse();
+
+	reassembly_table_register(&jaus_reassembly_table, &addresses_ports_reassembly_table_functions);
+}
+
+/**
+ * This function is called to register a handoff for our protocol
+ * Whenever a packet on the udp port is received, wireshark will call dissect_jaus()
+ *
+ * This may be call more then once by wireshark, preferences updates
+ */
+void proto_reg_handoff_jaus(void)
+{
+	static int jaus_inited = FALSE;
+	static guint jaus_port;
+	static guint jaus_extra_port;
+	static dissector_handle_t jaus_handle;
+	
+	if ( !jaus_inited )
+	{
+		/* Create a dissector handle for the Jmirror protocol */
+		jaus_handle = create_dissector_handle(dissect_jaus, proto_jaus);
+		
+		/* Set the init flag */
+		jaus_inited = TRUE;
+	} else {
+		/* Unregister from the old UDP port */
+		dissector_delete_uint("tcp.port", jaus_port, jaus_handle);
+		dissector_delete_uint("udp.port", jaus_port, jaus_handle);
+		dissector_delete_uint("udp.port", jaus_extra_port, jaus_handle);
+	}
+	
+	jaus_port = global_jaus_port;
+	jaus_extra_port = global_jaus_extra_port;
+	
+	/* Register as a normal IP dissector with default UDP port 3794 */
+	dissector_add_uint("tcp.port", jaus_port, jaus_handle);
+	dissector_add_uint("udp.port", jaus_port, jaus_handle);
+	dissector_add_uint("udp.port", jaus_extra_port, jaus_handle);
+}
+
+static int
+dissect_jaus(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void *data)
+{
+
+	guint8 version = 0;
+
+	/* get the first byte to check for the version of jaus message */
+	version = tvb_get_guint8( tvb, 0 );
+
+	if (version == 'J') { /* Legacy Header RA3 */
+		return dissect_RA3_header(tvb, pinfo, tree);
+	} else if (version == 2) { /* new transport spec v2 */
+		return dissect_sdp_header(tvb, pinfo, tree);
+	} else { /* unsupported */
+		return 0;
+	}
+
+}
+
+/**
+ * Starts the dissection of the new header.
+ *
+ * Return value is the amount that was dissected
+ */
+int dissect_sdp_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
+{
+	proto_item *jaus_item = NULL;
+	proto_item *jaus_sub_item = NULL;
+	proto_tree *jaus_tree = NULL;
+	//proto_tree *jaus_sub_tree = NULL;
+	proto_tree *jaus_header_tree = NULL;
+/*	proto_tree *jaus_properties_tree = NULL;
+	proto_tree *jaus_dest_tree = NULL;
+	proto_tree *jaus_src_tree = NULL;
+	proto_tree *jaus_dataC_tree = NULL;   */
+	proto_tree *jaus_payload_tree = NULL;
+	proto_tree *jaus_command_tree = NULL;
+
+	int offset = 1; /* starting offset in buffer */
+
+	guint8 hc = 0;
+	guint8 compression = 0; /* flag for using compression */
+	guint16 data_size = 0;
+	guint8 hc_num = 0;
+	guint8 hc_length = 0;
+	guint8 properties = 0;
+	guint16 command = 0;
+
+	int bytes;
+
+
+	/* Make entries in Protocol column and Info column on summary display */
+	if (check_col(pinfo->cinfo, COL_PROTOCOL)) {
+		col_set_str(pinfo->cinfo, COL_PROTOCOL, PROTO_TAG_JAUS);
+	}
+
+	/* Clear out stuff in the info column if present*/
+	if (check_col(pinfo->cinfo,COL_INFO)) {
+		col_clear(pinfo->cinfo,COL_INFO);
+	}
+
+	if (tree) {
+		/* JAUS Main tree */
+		jaus_item = proto_tree_add_item(tree, proto_jaus, tvb, 0, -1, FALSE);
+		jaus_tree = proto_item_add_subtree(jaus_item, ett_jaus);
+
+	}
+
+	hc = tvb_get_guint8( tvb, offset );
+
+	if ((hc & HC_FLAG) != 0) {
+		compression = 1;
+	}
+
+	if (tree) {
+		/* Header Sub tree */
+		jaus_sub_item = proto_tree_add_text(jaus_tree, tvb, offset, (!compression)? 12: 3, "Message Header");
+		jaus_header_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_header);
+
+		/* add message type and hc to header tree */
+		proto_tree_add_item(jaus_header_tree, hf_jaus_message_type, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+		proto_tree_add_item(jaus_header_tree, hf_jaus_hc, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+	}
+
+	offset+=1;
+
+	if (!compression) {
+		data_size = tvb_get_letohs(tvb, offset);
+
+
+		if (data_size < 14) {
+			/* data too small */
+			if (check_col(pinfo->cinfo, COL_INFO)) {
+				col_add_fstr(pinfo->cinfo, COL_INFO, "[ERROR Data Size is below the minimum value of 14]");
+			}
+			if (tree) {
+				/* add error data_size to header tree */
+				proto_tree_add_text(jaus_header_tree, tvb, offset, 2, "[ERROR Data Size is below the minimum value of 14]");
+			}
+			return offset;
+		}
+
+		if (data_size != (tvb_length(tvb) -1) ) {
+			/* error in packet size */
+			if (check_col(pinfo->cinfo, COL_INFO)) {
+				col_add_fstr(pinfo->cinfo, COL_INFO, "[ERROR Data Size (%d) does not match size of packet (%d)]", data_size, (tvb_length(tvb)-1));
+			}
+			if (tree) {
+				/* add error data_size to header tree */
+				proto_tree_add_text(jaus_header_tree, tvb, offset, 2, "[ERROR Data Size (%d) does not match size of packet (%d)]", data_size, (tvb_length(tvb)-1) );
+			}
+			return offset;
+		}
+
+		if (tree) {
+			/* add data_size to header tree */
+			proto_tree_add_item(jaus_header_tree, hf_jaus_data_size2, tvb, offset, 2, ENC_LITTLE_ENDIAN);
+		}
+		offset+=2;
+	}
+
+	if (compression) {
+
+		hc_num = tvb_get_guint8(tvb, offset);
+		if (tree) {
+			/* add hc_mun to header tree */
+			proto_tree_add_item(jaus_header_tree, hf_jaus_hc_num, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+		}
+		offset+=1;
+
+		hc_length = tvb_get_guint8(tvb, offset);
+		if (tree) {
+			/* add hc_length to header tree */
+			proto_tree_add_item(jaus_header_tree, hf_jaus_hc_lenght, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+		}
+		offset+=1;
+
+	}
+
+	if (!compression) {
+
+		properties = tvb_get_guint8(tvb, offset);
+		const guint8 data_flag = ( properties >> 6 ) & 0x3;
+
+		if (tree) {
+			/* add properties to header tree */
+			proto_tree_add_item(jaus_header_tree, hf_jaus_priority2, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+			proto_tree_add_item(jaus_header_tree, hf_jaus_bcast, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+			proto_tree_add_item(jaus_header_tree, hf_jaus_acknak2, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+			proto_tree_add_item(jaus_header_tree, hf_jaus_data_flag2, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+		}
+		offset+=1;
+
+		if (tree) {
+			/* add destination to header tree */
+			char dst_addr[14];
+			get_sdp_id_from_tvb(tvb, offset, dst_addr);
+			proto_tree_add_string(jaus_header_tree, hf_jaus_destination, tvb, offset, 4, dst_addr);
+		}
+		offset+=4;
+
+		if (tree) {
+			/* add source to header tree */
+			char src_addr[14];
+			get_sdp_id_from_tvb(tvb, offset, src_addr);
+			proto_tree_add_string(jaus_header_tree, hf_jaus_source, tvb, offset, 4, src_addr);
+		}
+		offset+=4;
+
+		/* beginning of n-byte payload
+		 * This could be empty?, or many messages
+		 */
+		if (tvb_length_remaining(tvb, offset) > 2) {
+			bytes = tvb_length_remaining(tvb, offset) - 2;
+			if (tree) {
+				jaus_sub_item = proto_tree_add_text(jaus_tree, tvb, offset, bytes, "Payload (%d byte%s)", bytes, plurality(bytes, "", "s"));
+				jaus_payload_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_data);
+			}
+		}
+
+		if (data_flag != 0) // JAUS Fragment
+		{
+			const uint16_t sequence_id = tvb_get_letohs(tvb, offset + bytes);
+			const gboolean first = data_flag == 1;
+			const gboolean last = data_flag == 3;
+			const guint32 max_frags = 100; // A big number that is used in JuniorMgr.
+
+			fragment_head *frag_msg = fragment_add_seq_single(&jaus_reassembly_table, tvb, offset, pinfo, sequence_id, NULL, bytes, first, last, max_frags);
+
+			tvbuff_t *new_tvb = process_reassembled_data(tvb, offset, pinfo, "Reassembled JAUS", frag_msg, &jaus_frag_items, NULL, jaus_tree);
+
+			if (new_tvb) // Reassembled
+			{
+				proto_item *jaus_reassembled_payload_item = NULL;
+				proto_tree *jaus_reassembled_payload_tree = NULL;
+				gint new_bytes = tvb_length(new_tvb);
+				gint new_offset = 0;
+				if (tree)
+				{
+					jaus_reassembled_payload_item = proto_tree_add_text(jaus_tree, new_tvb, new_offset, new_bytes, "Reassembled Payload (%d byte%s)", new_bytes, plurality(new_bytes, "", "s"));
+					jaus_reassembled_payload_tree = proto_item_add_subtree(jaus_reassembled_payload_item, ett_jaus_data);
+				}
+				// Reassembled message doesn't contain sequence id at end. Don't reserve any bytes at end.
+				new_offset = dissect_packet_data(new_tvb, pinfo, jaus_reassembled_payload_tree, new_offset, 0);
+
+				if (check_col(pinfo->cinfo, COL_INFO))
+				{
+					col_append_fstr(pinfo->cinfo, COL_INFO, "(Reassembled) ");
+				}
+			}
+			else // Not assembled yet
+			{
+				if (tree) {
+					proto_tree_add_item(jaus_payload_tree, hf_jaus_data, tvb, offset, bytes, FALSE);
+					offset += bytes;
+				}
+
+				if (check_col(pinfo->cinfo, COL_INFO)) {
+					col_append_fstr(pinfo->cinfo, COL_INFO, "Fragmented JAUS Protocol (flag=%s)", val_to_str(pinfo->pool,data_flag, data_flag_vals, "Unknown (0x%02x)"));
+				}
+			}
+
+		}
+		else // Not Fragmented
+		{
+			// Reserve 2 bytes for the sequence id.
+			offset = dissect_packet_data(tvb, pinfo, jaus_payload_tree, offset, 2);
+		}
+	}
+
+	if (!compression) {
+		while (tvb_length_remaining(tvb, offset) > 2) {
+			offset++;
+		}
+
+		proto_tree_add_item(jaus_tree, hf_jaus_sequenceNumber, tvb, offset, 2, ENC_LITTLE_ENDIAN);
+		offset+=2;
+	}
+
+	/* Return the amount of data this dissector was able to dissect */
+	return(offset);
+}
+
+/**
+ * Starts the dissection of the RA3 header.
+ *
+ * Return value is the amount that was dissected
+ */
+int dissect_RA3_header(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree)
+{
+	proto_item *jaus_item = NULL;
+	proto_item *jaus_sub_item = NULL;
+	proto_tree *jaus_tree = NULL;
+	//proto_tree *jaus_sub_tree = NULL;
+	proto_tree *jaus_header_tree = NULL;
+	proto_tree *jaus_properties_tree = NULL;
+	proto_tree *jaus_dest_tree = NULL;
+	proto_tree *jaus_src_tree = NULL;
+	proto_tree *jaus_dataC_tree = NULL;
+	proto_tree *jaus_data_tree = NULL;
+
+	message_def_t *m_ptr;
+
+	int offset = 0;
+	guint8 properties = 0;
+	guint16 command = 0;
+	guint16 dataC = 0;
+
+	int bytes;
+
+	/* Check that there's enough data, at least a Jaus header */
+	if (tvb_length(tvb) < JAUS_MIN_LEN)
+		return 0;
+
+	/*	Checks for the JAUS01.0 string to make sure it is a JAUS Message */
+	if ( strcmp(tvb_get_ephemeral_string(tvb, offset, 8), JAUS_START_STRING) != 0)
+		/*  This packet does not appear to belong to JAUS.
+		 *  Return 0 to give another dissector a chance to dissect it.
+		 */
+		return 0;
+
+	/* increment the offset to get past the 8 bytes indicating message */
+	offset += 8;
+
+	/* Make entries in Protocol column and Info column on summary display */
+	if (check_col(pinfo->cinfo, COL_PROTOCOL)) {
+		col_set_str(pinfo->cinfo, COL_PROTOCOL, PROTO_TAG_JAUS);
+	}
+
+	/* Clear out stuff in the info column if present*/
+	if (check_col(pinfo->cinfo,COL_INFO)) {
+		col_clear(pinfo->cinfo,COL_INFO);
+	}
+
+	/* Here we check to see if the INFO column is present. If it is we output
+	* which ports the packet came from and went to. Also, we indicate the type
+	* of packet.
+	*/
+
+	command = tvb_get_letohs(tvb , offset+2 );
+
+	m_ptr = get_message_def(command);
+
+	properties = tvb_get_guint8(tvb, offset);
+
+	if (check_col(pinfo->cinfo, COL_INFO)) {
+		col_add_fstr(pinfo->cinfo, COL_INFO, "Cmd(0x%04X) %s  %s  [priority %d]", command, (m_ptr)?m_ptr->name:" --- ",
+				(((properties&JAUS_ACKNAK_FLAG) >> 4)!= 0)? val_to_str_const(((properties&JAUS_ACKNAK_FLAG) >> 4), acknak_flag, "Unknown") : "",
+				(properties&JAUS_PRIORITY_FLAG));
+	}
+
+	if (tree) { /* we are being asked for a tree*/
+
+		/* JAUS Main tree */
+		jaus_item = proto_tree_add_protocol_format(tree, proto_jaus, tvb, 0, -1, "JAUS Robots, Msg: %s, is_Command: %s", (m_ptr) ? m_ptr->name : "NotFoundInXML",
+			(m_ptr) ? ((m_ptr->is_command) ? "true" : "false") : "NotFoundInXML");
+		jaus_tree = proto_item_add_subtree(jaus_item, ett_jaus);
+
+		/* Legacy RA3 Header */
+		/* Header Sub tree */
+		jaus_sub_item = proto_tree_add_text(jaus_tree, tvb, offset, 16, "Message Header, Cmd: 0x%04X", command);
+		jaus_header_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_header);
+		/* Message Properties sub tree of Header */
+		jaus_sub_item = proto_tree_add_text(jaus_header_tree, tvb, offset, 2, "Message Properties " );
+		jaus_properties_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_message_properties);
+		/* submit the priority parameter to Message Properties.  */
+		proto_tree_add_item(jaus_properties_tree, hf_jaus_priority, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+		/* submit the acknak parameter to Message Properties.  */
+		proto_tree_add_item(jaus_properties_tree, hf_jaus_acknak, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+		/* submit the service parameter to Message Properties.  */
+		proto_tree_add_item(jaus_properties_tree, hf_jaus_service, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+		/* submit the experimental parameter to Message Properties.  */
+		proto_tree_add_item(jaus_properties_tree, hf_jaus_experimental, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+	}
+	offset += 1;
+
+	if (tree) {
+		/* submit the version parameter to Message Properties.  */
+		proto_tree_add_item(jaus_properties_tree, hf_jaus_version, tvb, offset, 1, ENC_LITTLE_ENDIAN);
+	}
+	offset += 1;
+
+	if (tree) {
+		/* submit the commandCode parameter to Header sub tree. */
+		proto_tree_add_uint_format(jaus_header_tree, hf_jaus_commandCode, tvb, offset, 2, command,
+				"Command Code: %s (0x%04X)", (m_ptr) ? m_ptr->name : "NotFoundInXML", command);
+	}
+	offset += 2;
+
+	if (tree) {
+		/* Destination Sub tree of Header. */
+		char dst_addr[16];
+		get_ra3_id_from_tvb(tvb, offset, dst_addr);
+		jaus_sub_item = proto_tree_add_string(jaus_header_tree, hf_jaus_destination, tvb, offset, 4, dst_addr);
+		jaus_dest_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_destination);
+		/* Dest IP split apart, added to Destnation */
+		proto_tree_add_item(jaus_dest_tree, hf_jaus_dest_sub, tvb, offset, 4, ENC_LITTLE_ENDIAN);
+		proto_tree_add_item(jaus_dest_tree, hf_jaus_dest_node, tvb, offset, 4, ENC_LITTLE_ENDIAN);
+		proto_tree_add_item(jaus_dest_tree, hf_jaus_dest_comp, tvb, offset, 4, ENC_LITTLE_ENDIAN);
+		proto_tree_add_item(jaus_dest_tree, hf_jaus_dest_inst, tvb, offset, 4, ENC_LITTLE_ENDIAN);
+	}
+	offset += 4;
+
+	if (tree) {
+		/* Source Sub tree of Header */
+		char src_addr[16];
+		get_ra3_id_from_tvb(tvb, offset, src_addr);
+		jaus_sub_item = proto_tree_add_string(jaus_header_tree, hf_jaus_source, tvb, offset, 4, src_addr);
+		jaus_src_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_source);
+		/* Src IP split apart, added to Source */
+		proto_tree_add_item(jaus_src_tree, hf_jaus_src_sub, tvb, offset, 4, ENC_LITTLE_ENDIAN);
+		proto_tree_add_item(jaus_src_tree, hf_jaus_src_node, tvb, offset, 4, ENC_LITTLE_ENDIAN);
+		proto_tree_add_item(jaus_src_tree, hf_jaus_src_comp, tvb, offset, 4, ENC_LITTLE_ENDIAN);
+		proto_tree_add_item(jaus_src_tree, hf_jaus_src_inst, tvb, offset, 4, ENC_LITTLE_ENDIAN);
+	}
+	offset += 4;
+
+	dataC = tvb_get_letohs(tvb,offset);
+
+	if (tree) {
+		/* dataControl Sub tree of Header. */
+		jaus_sub_item = proto_tree_add_item(jaus_header_tree, hf_jaus_dataControl, tvb, offset, 2, ENC_LITTLE_ENDIAN);
+		jaus_dataC_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_dataControl);
+		/* DataC info split apart, added to dataControl */
+		proto_tree_add_item(jaus_dataC_tree, hf_jaus_data_size, tvb, offset, 2, ENC_LITTLE_ENDIAN);
+		proto_tree_add_item(jaus_dataC_tree, hf_jaus_data_flag, tvb, offset, 2, ENC_LITTLE_ENDIAN);
+	}
+	offset+=2;
+
+	if (tree) {
+		/* submit the sequenceNumber parameter to Header Sub tree. */
+		proto_tree_add_item(jaus_header_tree, hf_jaus_sequenceNumber, tvb, offset, 2, ENC_LITTLE_ENDIAN);
+	}
+	offset+=2;
+
+	if (tree) {
+		/* show the rest of the Data in the message */
+		bytes = tvb_length_remaining(tvb, offset);
+		if (bytes > 0) {
+			jaus_sub_item = proto_tree_add_text(jaus_tree, tvb, offset, bytes, "Data (%d byte%s)", bytes, plurality(bytes, "", "s"));
+			jaus_data_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_data);
+
+			if (bytes == (dataC & 0xfff)) {
+				if (m_ptr) {
+					offset = dissect_message_data(tvb, jaus_data_tree, offset, m_ptr);
+					if (offset < 0) {return data_offset;}
+				} else {/* if no message found then show the data  */
+					proto_item_append_text(jaus_sub_item, ", No message_def found in XML to dissect data");
+					proto_tree_add_item(jaus_data_tree, hf_jaus_data, tvb, offset, bytes, FALSE);
+				}
+			} else {
+				proto_item_append_text(jaus_sub_item, ", [ERROR Data remaining (%d) does not match Data Control Size (%d)]",
+					bytes, (dataC & 0xfff));
+				proto_tree_add_item(jaus_data_tree, hf_jaus_data, tvb, offset, bytes, FALSE);
+			}
+		}
+	}
+
+	return offset;
+}
+
+/**
+ * Prints an Error message to the current tree location
+ *    for the different types of errors
+ *
+ */
+void print_error(tvbuff_t *tvb, proto_tree *tree, int error)
+{
+	if (error == -1) {
+		proto_tree_add_text(tree, tvb, data_offset, -1, "[ERROR: Unkown data_type, check xml]");
+	} else if (error == -2) {
+		proto_tree_add_text(tree, tvb, data_offset, -1, "[ERROR: Malformed packet, not enough data]");
+	}
+}
+
+int dissect_array(tvbuff_t *tvb, proto_tree *tree, array_t *a_ptr)
+{
+	proto_item *sub_item = NULL;
+	proto_tree *sub_tree = NULL;
+
+	dimension_t *d_ptr;
+
+	int size = 1;
+	int error;
+
+	/* print bit_field value to bit_field tree of the tree*/
+	sub_item = proto_tree_add_text(tree, tvb, data_offset, 1, "[ARRAY] %s (%s)",
+		a_ptr->name, (a_ptr->optional) ? "optional" : "req");
+	sub_tree = proto_item_add_subtree(sub_item, ett_array);
+
+
+	proto_item_append_text(sub_item, ",[Dimension] ");
+	d_ptr = a_ptr->dimension;
+	while (d_ptr != NULL) {
+		size *= d_ptr->size;
+		proto_item_append_text(sub_item, "%s(%d)%s", d_ptr->name, d_ptr->size, (d_ptr->next == NULL)?" ":"x");
+		d_ptr = d_ptr->next;
+	}
+
+	while (size != 0) {
+		error = dissect_message_field(tvb, tree, a_ptr->field, 0, 0);
+		if (error < 0) {return(error);}
+		size--;
+	}
+
+	return(0);
+}
+
+int dissect_fixed_field(tvbuff_t *tvb, proto_tree *tree, fixed_field_t *ff_ptr)
+{
+	scale_range_t *sr_ptr;
+	value_set_t *vs_ptr;
+	value_range_t *vr_ptr;
+	value_enum_t *ve_ptr;
+
+	guint64 data;
+	long datacopy;
+	double c_data;
+	int size;
+	int found = 0;
+	int error;
+
+	sr_ptr = ff_ptr->scale_range;
+	vs_ptr = ff_ptr->value_set;
+
+	/* Get data field size and data from buffer */
+	size = get_number_of_bytes(ff_ptr->field_type);
+	if (size < 0) {print_error(tvb, tree, size); return(size);}
+	error = get_data_from_tvb(tvb, data_offset, ff_ptr->field_type, size, &data);
+	if (error < 0) {print_error(tvb, tree, error); return(error);}
+
+	datacopy = (long) data;
+
+	if (sr_ptr != NULL) { /* scale_range */
+		c_data = scale_convert((unsigned int) data, (size * 8), sr_ptr->real_lower_limit, sr_ptr->real_upper_limit, sr_ptr->integer_function);
+
+		proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[FFsr] %s: (%s) %f",
+			ff_ptr->name, ff_ptr->field_units, c_data);
+
+	} else if (vs_ptr != NULL) { /* value_set */
+
+		vr_ptr = vs_ptr->value_range;
+		ve_ptr = vs_ptr->value_enum;
+
+		if (vs_ptr->offset_to_lower_limit == 0) { /* No offset_to_lower_limit */
+
+			/* value_enum: Find matching enum to data(index) pulled from buffer */
+			while (ve_ptr != NULL) {
+				if (data == ve_ptr->enum_index) {
+					proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[FFvs] %s: (%s) %s (%ld)",
+						ff_ptr->name, ff_ptr->field_units, ve_ptr->enum_const, data);
+					found = 1; break;
+				}
+				ve_ptr = ve_ptr->next;
+			}
+
+			if (!found) {
+				/* value_range */
+				while (vr_ptr != NULL) {
+					if (vr_ptr->lower_limit <= data && data <= vr_ptr->upper_limit) {
+						if (strcmp(vr_ptr->interpretation,"none")) {
+							proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[FFvs] %s: (%s) %s (%ld)",
+								ff_ptr->name, ff_ptr->field_units, vr_ptr->interpretation, data);
+							found = 1; break;
+						}
+					}
+					vr_ptr = vr_ptr->next;
+				}
+			}
+
+			if (!found) {
+				proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[FFvs] %s: (%s) %ld (0x%lX)",
+					ff_ptr->name, ff_ptr->field_units, datacopy, data);
+			}
+
+		} else { /* offset_to_lower_limit */
+			/* TODO */
+			proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[FFvs] %s: (%s) 0x%lX (offset->lower TODO)",
+				ff_ptr->name, ff_ptr->field_units, data);
+		}
+
+	} else { /* fixed_field without a scale_range for value_set */
+		/* test to see if unsigned or signed to print out different ways */
+		if ( ff_ptr->field_type > PDT_LONG_INT)
+			proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[FF] %s: (%s) %lu (0x%lX)",
+				ff_ptr->name, ff_ptr->field_units, datacopy, data);
+		else
+			proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[FF] %s: (%s) %ld (0x%lX)",
+				ff_ptr->name, ff_ptr->field_units, datacopy, data);
+	}
+
+	data_offset += size;
+	return(0);
+}
+
+int dissect_variable_field(tvbuff_t *tvb, proto_tree *tree, variable_field_t *vf_ptr)
+{
+	proto_item *sub_item = NULL;
+	proto_tree *sub_tree = NULL;
+
+	type_and_units_enum_t *taue_ptr;
+	scale_range_t *sr_ptr;
+	value_set_t *vs_ptr;
+	value_range_t *vr_ptr;
+	value_enum_t *ve_ptr;
+
+	guint64 data, index;
+	int offset, size;
+	int found = 0;
+	double c_data;
+	int error;
+
+	offset = data_offset;
+
+	sub_item = proto_tree_add_text(tree, tvb, offset, 1, "[VF] %s (%s)",
+		vf_ptr->name, (vf_ptr->optional) ? "optional" : "req");
+	sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+	// Read the variable field index
+	error = get_data_from_tvb(tvb, offset, PDT_UBYTE, 1, &index);
+	offset += 1;
+
+	// Loop through the type_and_units_enum, looking for a matching index. When found, display it.
+	taue_ptr = vf_ptr->taue;
+	while (taue_ptr != NULL) {
+		/* Get data field size and data from buffer */
+		size = get_number_of_bytes(taue_ptr->field_type);
+		if (size < 0) {print_error(tvb, tree, size); return(size);}
+		error = get_data_from_tvb(tvb, offset, taue_ptr->field_type, size, &data);
+		if (error < 0) {print_error(tvb, tree, error); return(error);}
+
+		sr_ptr = taue_ptr->scale_range;
+		vs_ptr = taue_ptr->value_set;
+
+		if (sr_ptr != NULL) { /* scale_range */
+			c_data = scale_convert((unsigned int) data, (size * 8), sr_ptr->real_lower_limit, sr_ptr->real_upper_limit, sr_ptr->integer_function);
+
+			if (index == taue_ptr->index) {
+				proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, offset, size, data, "[VFsr] %s (index: %d, %s) %f",
+					taue_ptr->name, taue_ptr->index, taue_ptr->field_units, c_data);
+					offset += size;
+					break;
+			}
+
+		} else if (vs_ptr != NULL) { /* value_set */
+
+			vr_ptr = vs_ptr->value_range;
+			ve_ptr = vs_ptr->value_enum;
+
+			if (vs_ptr->offset_to_lower_limit == 0) { /* No offset_to_lower_limit */
+
+				/* value_enum: Find matching enum to data(index) pulled from buffer */
+				while (ve_ptr != NULL) {
+					if (data == ve_ptr->enum_index) {
+						proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, offset, size, data, "[VFvs] %s (index: %d, %s) %s (%ld)",
+							taue_ptr->name, taue_ptr->index, taue_ptr->field_units, ve_ptr->enum_const, data);
+						found = 1; break;
+					}
+					ve_ptr = ve_ptr->next;
+				}
+
+				if (!found) {
+				/* value_range*/
+					while (vr_ptr != NULL) {
+						if (vr_ptr->lower_limit <= data && data <= vr_ptr->upper_limit) {
+							if (strcmp(vr_ptr->interpretation,"none")) {
+								proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, offset, size, data, "[VFvs] index: %d (%s) %s (%ld)",
+									taue_ptr->index, taue_ptr->field_units, vr_ptr->interpretation, data);
+								found = 1; break;
+							}
+						}
+						vr_ptr = vr_ptr->next;
+					}
+				}
+
+				if (!found)
+					proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, offset, size, data, "[VFvs] index: %d (%s) %ld",
+						taue_ptr->index, taue_ptr->field_units, data);
+
+			} else { /* offset_to_lower_limit */
+				/* TODO */
+				proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, offset, size, data, "[VFvs] index: %d (%s) 0x%lX (offset->lower TODO)",
+					taue_ptr->index, taue_ptr->field_units, data);
+			}
+
+		} else {
+			/* variable_field without a scale_range for value_set */
+			if (index == taue_ptr->index) {
+				proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, offset, size, data, "[VF] %s (index: %d, %s) 0x%lX",
+					taue_ptr->name, taue_ptr->index, taue_ptr->field_units, data);
+				offset += size;
+				break;
+			}
+		}
+
+		taue_ptr = taue_ptr->next;
+	}
+
+	data_offset = offset;
+	return(0);
+}
+
+int dissect_bit_field(tvbuff_t *tvb, proto_tree *tree, bit_field_t *bf_ptr)
+{
+	proto_item *sub_item = NULL;
+	proto_tree *sub_tree = NULL;
+
+	sub_field_t *sf_ptr;
+	value_range_t *vr_ptr;
+	value_enum_t *ve_ptr;
+
+	guint64 data, sub_data;
+	int size, mask;
+	unsigned char count;
+	int error;
+
+	/* Get data field size and data from buffer */
+	size = get_number_of_bytes(bf_ptr->field_type_unsigned);
+	if (size < 0) {print_error(tvb, tree, size); return(size);}
+	error = get_data_from_tvb(tvb, data_offset, bf_ptr->field_type_unsigned, size, &data);
+	if (error < 0) {print_error(tvb, tree, error); return(error);}
+
+	/* print bit_field value to bit_field tree of the tree*/
+	sub_item = proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, data_offset, size, data, "[BF] %s (%d) %s [0x%lX]",
+		bf_ptr->name, bf_ptr->field_type_unsigned, (bf_ptr->optional) ? "optional" : "req", data);
+	sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+
+	/* print sub_field values to a sub tree of bit_fields tree */
+	sf_ptr = bf_ptr->sub_field;
+	while (sf_ptr != NULL) {
+		int found = 0;
+		count = sf_ptr->to_index - sf_ptr->from_index;
+		mask = 0x01;
+		while (count > 0) {
+			mask = (mask << 1) | 0x01;
+			count--;
+		}
+
+		sub_data = (data >> sf_ptr->from_index) & mask;
+
+		/* TODO check to see if sub_data is with-in value_range and/or has value_enum */
+		/* value_set information */
+		vr_ptr = sf_ptr->value_range;
+		ve_ptr = sf_ptr->value_enum;
+
+		/* value_enum: Find matching enum to data(index) pulled from buffer */
+		while (ve_ptr != NULL) {
+			if (sub_data == ve_ptr->enum_index) {
+				proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, data_offset, size, sub_data, "[BFsf] %s: %s (%ld)",
+					sf_ptr->name, ve_ptr->enum_const, sub_data);
+				found = 1; break;
+			}
+			ve_ptr = ve_ptr->next;
+		}
+
+		if (!found) {
+			/* value_range */
+			while (vr_ptr != NULL) {
+				if (vr_ptr->lower_limit <= data && data <= vr_ptr->upper_limit) {
+					if (strcmp(vr_ptr->interpretation,"none")) {
+						proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, data_offset, size, sub_data, "[BFsf] %s: %s (%ld)",
+							sf_ptr->name, vr_ptr->interpretation, sub_data);
+						found = 1; break;
+					}
+				}
+				vr_ptr = vr_ptr->next;
+			}
+		}
+
+		if (!found)
+			proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, data_offset, size, sub_data, "[BFsf] %s: %ld",
+				sf_ptr->name, sub_data);
+
+		sf_ptr = sf_ptr->next;
+	}
+
+	data_offset += size;
+	return(0);
+}
+
+int dissect_fixed_length_string(tvbuff_t *tvb, proto_tree *tree, fixed_length_string_t *fls_ptr)
+{
+	guint8 *string;
+	unsigned int size;
+
+	/* Get data field size and data from buffer */
+	size = fls_ptr->string_length;
+
+	if ((unsigned int)tvb_length_remaining(tvb, data_offset) < size) {
+		print_error(tvb, tree, -2); /* malformed packet likely */
+		return(-2);
+	}
+
+	string = tvb_get_ephemeral_string(tvb, data_offset, size);
+
+	proto_tree_add_text(tree, tvb, data_offset, size, "[FLS] %s(%d): %s",
+			fls_ptr->name, size, string);
+
+	data_offset += size;
+	return(0);
+}
+
+int dissect_variable_length_string(tvbuff_t *tvb, proto_tree *tree, variable_length_string_t *vls_ptr)
+{
+	count_field_t *cf_ptr;
+
+	guint8 *string;
+	guint64 string_length;
+	int size, offset;
+	int error;
+
+	offset = data_offset;
+
+	cf_ptr = vls_ptr->count_field;
+
+	/* Get data field size and data from buffer */
+	size = get_number_of_bytes(cf_ptr->field_type_unsigned);
+	if (size < 0) {print_error(tvb, tree, size); return(size);}
+	error = get_data_from_tvb(tvb, offset, cf_ptr->field_type_unsigned, size, &string_length);
+	if (error < 0) {print_error(tvb, tree, error); return(error);}
+
+	/* TODO? check min_count and max_count for count_field */
+
+	offset += size;
+
+	string = tvb_get_ephemeral_string(tvb, offset , (gint)string_length);
+
+	proto_tree_add_text(tree, tvb, offset, ((int)string_length + size), "[VLS] %s(%ld): %s",
+			vls_ptr->name, string_length, string);
+
+	data_offset = (offset + (int)string_length);
+	return(0);
+}
+
+int dissect_variable_length_field(tvbuff_t *tvb, proto_tree *tree, variable_length_field_t *vlf_ptr)
+{
+	count_field_t *cf_ptr;
+
+	guint8 *data;
+	guint64 field_length;
+	int size, offset;
+	int error;
+
+	offset = data_offset;
+
+	cf_ptr = vlf_ptr->count_field;
+
+	/* Get data field size and data from buffer */
+	size = get_number_of_bytes(cf_ptr->field_type_unsigned);
+	if (size < 0) {print_error(tvb, tree, size); return(size);}
+	error = get_data_from_tvb(tvb, offset, cf_ptr->field_type_unsigned, size, &field_length);
+	if (error < 0) {print_error(tvb, tree, error); return(error);}
+
+
+	/* TODO? check min_count and max_count for count_field */
+
+	offset += size;
+
+	proto_item *vlf_item = proto_tree_add_text(
+		tree, tvb, offset, ((int)field_length), "[VLF] %s: (%s)", vlf_ptr->name, vlf_ptr->field_format);
+	proto_tree *vlf_tree = proto_item_add_subtree(vlf_item, ett_jaus_data);
+
+	const char *count_type = decode_field_type(cf_ptr->field_type_unsigned);
+
+	proto_tree_add_uint64_format(
+		vlf_tree, hf_jaus_uint64, tvb, data_offset, size, -1, "[CF] (%s) min: %d, max: %d, count: %lu",
+		count_type, cf_ptr->min_count, cf_ptr->max_count, field_length);
+
+	if (strcmp(vlf_ptr->field_format, "JAUS MESSAGE") == 0)
+	{
+		dissect_embedded_message_data(tvb, vlf_tree, offset);
+	}
+	else
+	{
+		data = ep_tvb_memdup(tvb, offset, (int)field_length);
+		proto_tree_add_bytes(vlf_tree, hf_jaus_data, tvb, offset, ((int)field_length), data);
+		data_offset = (offset + (int)field_length);
+	}
+	return (0);
+}
+
+int dissect_variable_format_field(tvbuff_t *tvb, proto_tree *tree, variable_format_field_t *vff_ptr)
+{
+	format_enum_t *fe_ptr;
+	count_field_t *cf_ptr;
+
+	guint64 count;
+	int offset;
+	int size, found_fe = 0;
+	int error;
+
+	offset = data_offset;
+	fe_ptr = vff_ptr->format_enum;
+	cf_ptr = vff_ptr->count_field;
+
+	const guint8 field_enum = tvb_get_guint8(tvb, offset);
+	offset += 1;
+
+	/* Find matching format_enum to data(index) pulled from buffer */
+	while (fe_ptr != NULL) {
+		if (field_enum == fe_ptr->index) {
+			found_fe = 1; break;
+		}
+		fe_ptr = fe_ptr->next;
+	}
+
+	/* Get data field size and data from buffer */
+	size = get_number_of_bytes(cf_ptr->field_type_unsigned);
+	if (size < 0) {print_error(tvb, tree, size); return(size);}
+	error = get_data_from_tvb(tvb, offset, cf_ptr->field_type_unsigned, size, &count);
+	if (error < 0) {print_error(tvb, tree, error); return(error);}
+	offset += size;
+
+	/* print with enum field_format name else error? with just the data from buffer */
+	const char *count_type = decode_field_type(cf_ptr->field_type_unsigned);
+	static char unknown_format[20];
+	sprintf(unknown_format, "UNKNOWN FORMAT(%u)",field_enum);
+	const char* format_string = (found_fe) ? fe_ptr->field_format : unknown_format;
+	proto_item* vff_item = proto_tree_add_uint64_format(tree, hf_jaus_uint64, tvb, offset, count, -1, "[VFF] %s (%s) %s [length: %ld]",
+		vff_ptr->name, count_type, format_string, count);
+	proto_tree *vff_tree = proto_item_add_subtree(vff_item, ett_jaus_data);
+
+	if (strcmp(fe_ptr->field_format, "JAUS MESSAGE") == 0)
+	{
+		dissect_embedded_message_data(tvb, vff_tree, offset);
+	}
+	else
+	{
+		guint8 *data = ep_tvb_memdup(tvb, offset, (int)count);
+		proto_tree_add_bytes(vff_tree, hf_jaus_data, tvb, offset, ((int)count), data);
+		data_offset = (offset + (int)count);
+	}
+
+	return(0);
+}
+
+int dissect_message_field(tvbuff_t *tvb, proto_tree *tree, field_t *f_ptr, int _op_count, guint64 presence_vector)
+{
+	array_t *a_ptr;
+	fixed_field_t *ff_ptr;
+	variable_field_t *vf_ptr;
+	bit_field_t *bf_ptr;
+	fixed_length_string_t *fls_ptr;
+	variable_length_string_t *vls_ptr;
+	variable_length_field_t *vlf_ptr;
+	variable_format_field_t *vff_ptr;
+
+	int op_count = _op_count;
+	int error;
+
+	switch (f_ptr->type) {
+		case ARRAY_TYPE:
+			a_ptr = (array_t *)f_ptr->field;
+			if ((!a_ptr->optional) || ((presence_vector >> op_count) & 0x01)) {
+
+				error = dissect_array(tvb, tree, a_ptr);
+				if (error < 0) {return(error);}
+
+			}
+			if (a_ptr->optional)
+				op_count++;
+			break;
+		case FIXED_FIELD_TYPE:
+			ff_ptr = (fixed_field_t *)f_ptr->field;
+			if ((!ff_ptr->optional) || ((presence_vector >> op_count) & 0x01)) {
+
+				error = dissect_fixed_field(tvb, tree, ff_ptr);
+				if (error < 0) {return(error);}
+
+			}
+			if (ff_ptr->optional)
+				op_count++;
+			break;
+		case VARIABLE_FIELD_TYPE:
+			vf_ptr = (variable_field_t *)f_ptr->field;
+			if ((!vf_ptr->optional) || ((presence_vector >> op_count) & 0x01)) {
+
+				error = dissect_variable_field(tvb, tree, vf_ptr);
+				if (error < 0) {return(error);}
+
+			}
+			if (vf_ptr->optional)
+				op_count++;
+			break;
+		case BIT_FIELD_TYPE:
+			bf_ptr = (bit_field_t *)f_ptr->field;
+			if ((!bf_ptr->optional) || ((presence_vector >> op_count) & 0x01)) {
+
+				error = dissect_bit_field(tvb, tree, bf_ptr);
+				if (error < 0) {return(error);}
+
+			}
+			if (bf_ptr->optional)
+				op_count++;
+			break;
+		case FIXED_LENGTH_STRING_TYPE:
+			fls_ptr = (fixed_length_string_t *)f_ptr->field;
+			if ((!fls_ptr->optional) || ((presence_vector >> op_count) & 0x01)) {
+
+				error = dissect_fixed_length_string(tvb, tree, fls_ptr);
+				if (error < 0) {return(error);}
+
+			}
+			if (fls_ptr->optional)
+				op_count++;
+			break;
+		case VARIABLE_LENGTH_STRING_TYPE:
+			vls_ptr = (variable_length_string_t *)f_ptr->field;
+			if ((!vls_ptr->optional) || ((presence_vector >> op_count) & 0x01)) {
+
+				error = dissect_variable_length_string(tvb, tree, vls_ptr);
+				if (error < 0) {return(error);}
+
+			}
+			if (vls_ptr->optional)
+				op_count++;
+			break;
+		case VARIABLE_LENGTH_FIELD_TYPE:
+			vlf_ptr = (variable_length_field_t *)f_ptr->field;
+			if ((!vlf_ptr->optional) || ((presence_vector >> op_count) & 0x01)) {
+
+				error = dissect_variable_length_field(tvb, tree, vlf_ptr);
+				if (error < 0) {return(error);}
+
+			}
+			if (vlf_ptr->optional)
+				op_count++;
+			break;
+		case VARIABLE_FORMAT_FIELD_TYPE:
+			vff_ptr = (variable_format_field_t *)f_ptr->field;
+			if ((!vff_ptr->optional) || ((presence_vector >> op_count) & 0x01)) {
+
+				error = dissect_variable_format_field(tvb, tree, vff_ptr);
+				if (error < 0) {return(error);}
+
+			}
+			if (vff_ptr->optional)
+				op_count++;
+			break;
+		default:
+			proto_tree_add_text(tree, tvb, data_offset, -1, "No supported printout for field_type");
+	}
+	return(op_count);
+}
+
+int dissect_message_comp(tvbuff_t *tvb, proto_tree *tree, field_t *f_ptr, int _c_op_count, guint64 presence_vector)
+{
+	proto_item *sub_item = NULL;
+	proto_tree *sub_tree = NULL;
+
+	field_t *lf_ptr;
+
+	record_t *r_ptr;
+	list_t *l_ptr;
+		count_field_t *cf_ptr;
+	variant_t *v_ptr;
+	sequence_t *s_ptr;
+
+	guint64 data, l_presence_vector = 0;
+
+	int op_count, c_op_count, size;
+	int error;
+
+	c_op_count = _c_op_count;
+
+	switch (f_ptr->type) {
+		case RECORD_TYPE:
+			r_ptr = (record_t *)f_ptr->field;
+			if ((!r_ptr->optional) || ((presence_vector >> c_op_count) & 0x01)) {
+				/* record subtree of the tree*/
+				sub_item = proto_tree_add_text(tree, tvb, data_offset, 1, "[RECORD]: %s (%s)", r_ptr->name,
+					(r_ptr->optional) ? "optional" : "req");
+				sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+				/* check to see if there is a presence_vector for this message */
+				if (r_ptr->presence_vector_type != PDT_OP) {
+					size = get_number_of_bytes(r_ptr->presence_vector_type);
+					if (size < 0) {print_error(tvb, tree, size); return(size);}
+					error = get_data_from_tvb(tvb, data_offset, r_ptr->presence_vector_type, size, &l_presence_vector);
+					if (error < 0) {print_error(tvb, tree, error); return(error);}
+					proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, data_offset, size, l_presence_vector, "[PV] (%d) 0x%lX",
+						r_ptr->presence_vector_type, l_presence_vector);
+					data_offset += size;
+				}
+				op_count = 0;
+
+				lf_ptr = r_ptr->field;
+				while (lf_ptr != NULL) {
+					op_count = dissect_message_field(tvb, sub_tree, lf_ptr, op_count, l_presence_vector);
+					if (op_count < 0) {return(op_count);}
+					lf_ptr = lf_ptr->next;
+				}
+			}
+			if (r_ptr->optional)
+				c_op_count++;
+			break;
+		case LIST_TYPE:
+			l_ptr = (list_t *)f_ptr->field;
+			if ((!l_ptr->optional) || ((presence_vector >> c_op_count) & 0x01)) {
+				/* list subtree of the tree*/
+				sub_item = proto_tree_add_text(tree, tvb, data_offset, 1, "[LIST]: %s (%s)", l_ptr->name,
+					(l_ptr->optional) ? "optional" : "req");
+				sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+
+				/* count_field data */
+				cf_ptr = l_ptr->count_field;
+				size = get_number_of_bytes(cf_ptr->field_type_unsigned);
+				if (size < 0) {print_error(tvb, tree, size); return(size);}
+				error = get_data_from_tvb(tvb, data_offset, cf_ptr->field_type_unsigned, size, &data);
+				if (error < 0) {print_error(tvb, tree, error); return(error);}
+				proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, data_offset, size, data, "[CF] (%d) min: %d, max: %d, count: %lu",
+					cf_ptr->field_type_unsigned, cf_ptr->min_count, cf_ptr->max_count, data);
+				data_offset += size;
+
+				lf_ptr = l_ptr->field;
+				if (cf_ptr->min_count != 0 && cf_ptr->max_count != 0) {
+					if (cf_ptr->min_count <= data && data <= cf_ptr->max_count) {
+						while (data != 0) {
+								c_op_count = dissect_message_comp(tvb, sub_tree, lf_ptr, c_op_count, l_presence_vector);
+								if (c_op_count < 0) {return(c_op_count);}
+								data--;
+						}
+					} else {
+						proto_tree_add_text(sub_tree, tvb, data_offset, 1, "[ERROR]: count out of range (%ld)", data);
+						break;
+					}
+				} else {
+					while (data != 0) {
+						if (lf_ptr != NULL) {
+							c_op_count = dissect_message_comp(tvb, sub_tree, lf_ptr, c_op_count, l_presence_vector);
+							if (c_op_count < 0) {return(c_op_count);}
+							data--;
+						}
+					}
+				}
+			}
+			if (l_ptr->optional)
+				c_op_count++;
+			break;
+		case VARIANT_TYPE:
+			v_ptr = (variant_t *)f_ptr->field;
+			if ((!v_ptr->optional) || ((presence_vector >> c_op_count) & 0x01)) {
+				/* variant subtree of the tree*/
+				sub_item = proto_tree_add_text(tree, tvb, data_offset, 1, "[VARIANT]: %s (%s)", v_ptr->name,
+					(v_ptr->optional) ? "optional" : "req");
+				sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+				/* vtag_field data */
+				size = get_number_of_bytes(v_ptr->field_type_unsigned);
+				if (size < 0) {print_error(tvb, tree, size); return(size);}
+				error = get_data_from_tvb(tvb, data_offset, v_ptr->field_type_unsigned, size, &data);
+				if (error < 0) {print_error(tvb, tree, error); return(error);}
+				proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, data_offset, size, data, "[VTAG] (%d) min: %d, max: %d, count: %lu",
+					v_ptr->field_type_unsigned, v_ptr->min_count, v_ptr->max_count, data);
+				data_offset += size;
+
+				lf_ptr = v_ptr->field;
+				while (data != 0) {
+					lf_ptr = lf_ptr->next;
+					data--;
+				}
+				if (lf_ptr != NULL) {
+					c_op_count = dissect_message_comp(tvb, tree, lf_ptr, c_op_count, l_presence_vector);
+					if (c_op_count < 0) {return(c_op_count);}
+				}
+			}
+			if (v_ptr->optional)
+				c_op_count++;
+			break;
+		case SEQUENCE_TYPE:
+			s_ptr = (sequence_t *)f_ptr->field;
+			if ((!s_ptr->optional) || ((presence_vector >> c_op_count) & 0x01)) {
+				/* sequence subtree of the tree*/
+				sub_item = proto_tree_add_text(tree, tvb, data_offset, 1, "[SEQUENCE]: %s (%s)", s_ptr->name,
+					(s_ptr->optional) ? "optional" : "req");
+				sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+
+				/* check to see if there is a presence_vector for this message */
+				if (s_ptr->presence_vector_type != PDT_OP) {
+					size = get_number_of_bytes(s_ptr->presence_vector_type);
+					if (size < 0) {print_error(tvb, tree, size); return(size);}
+					error = get_data_from_tvb(tvb, data_offset, s_ptr->presence_vector_type, size, &l_presence_vector);
+					if (error < 0) {print_error(tvb, tree, error); return(error);}
+					proto_tree_add_uint64_format(sub_tree, hf_jaus_uint64, tvb, data_offset, size, l_presence_vector, "[PV] (%d) 0x%lX",
+						s_ptr->presence_vector_type, l_presence_vector);
+					data_offset += size;
+				}
+
+				c_op_count = 0;
+				lf_ptr = s_ptr->field;
+				while (lf_ptr != NULL) {
+					c_op_count = dissect_message_comp(tvb, tree, lf_ptr, c_op_count, l_presence_vector);
+					if (c_op_count < 0) {return(c_op_count);}
+					lf_ptr = lf_ptr->next;
+				}
+			}
+			if (s_ptr->optional)
+				c_op_count++;
+			break;
+		default:
+			proto_tree_add_text(tree, tvb, data_offset, -1, "No supported printout for Composite field_type");
+	}
+	return(c_op_count);
+}
+
+int dissect_message_data(tvbuff_t *tvb, proto_tree *tree, int offset, message_def_t *m_ptr)
+{
+	field_t *f_ptr;
+	int error = 0;
+
+	data_offset = offset;
+
+	/* working with body of type record only right now */
+	f_ptr = m_ptr->body;
+	if (f_ptr != NULL) {
+
+		error = dissect_message_comp(tvb, tree, f_ptr, 0, 0);
+		if (error < 0) {return(error);}
+
+	} else {/* message found but no body record and data available */
+		proto_tree_add_item(tree, hf_jaus_data, tvb, offset, -1, FALSE);
+	}
+
+	return(data_offset);
+}
+
+int dissect_packet_data(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, int offset, int reserve_bytes)
+{
+	proto_item *jaus_sub_item = NULL;
+	proto_tree *jaus_command_tree = NULL;
+	while (tvb_length_remaining(tvb, offset) > reserve_bytes)
+	{ /* WHILE not last reserve_bytes */
+
+		guint16 command = tvb_get_letohs(tvb, offset);
+		message_def_t* m_ptr = get_message_def(command);
+
+		if (check_col(pinfo->cinfo, COL_INFO))
+		{
+			col_append_fstr(pinfo->cinfo, COL_INFO, "Cmd(0x%04X) %s, ", command, (m_ptr) ? m_ptr->name : " --- ");
+		}
+
+		if (tree)
+		{
+			proto_item_append_text(tree->parent, ", Msg: %s, is_Command: %s", (m_ptr) ? m_ptr->name : "NotFoundInXML",
+				(m_ptr) ? ((m_ptr->is_command) ? "true" : "false") : "NotFoundInXML");
+			/* submit the commandCode parameter to the payload sub tree. */
+			jaus_sub_item = proto_tree_add_uint_format(tree, hf_jaus_commandCode, tvb, offset, 2, command,
+														"Command Code: %s (0x%04X)", (m_ptr) ? m_ptr->name : "NotFoundInXML", command);
+			jaus_command_tree = proto_item_add_subtree(jaus_sub_item, ett_jaus_data);
+		}
+
+		offset += 2;
+
+		/* If the message is not found in the xml, offset to the next can not to found, just show the data and continue */
+		if (m_ptr)
+		{
+			offset = dissect_message_data(tvb, jaus_command_tree, offset, m_ptr);
+			if (offset < 0)
+			{
+				// Ran out of data to process. Something went wrong.
+				return offset;
+			}
+		}
+		else if (jaus_sub_item)
+		{
+			/* if no message found then show the data  */
+			proto_item_append_text(jaus_sub_item, ", No message_def found in XML to dissect data");
+			gint bytes = tvb_length_remaining(tvb, offset) - reserve_bytes;
+			proto_tree_add_item(jaus_command_tree, hf_jaus_data, tvb, offset, bytes, FALSE);
+			offset+=bytes;
+			break;
+		}
+
+	} /* END WHILE */
+	return offset;
+}
+
+int dissect_embedded_message_data(tvbuff_t *tvb, proto_tree *tree, int offset)
+{
+	guint16 command = tvb_get_letohs(tvb, offset);
+	message_def_t *message_def = get_message_def(command);
+
+	proto_item *sub_item = proto_tree_add_uint_format(
+		tree, hf_jaus_commandCode, tvb, offset, 2, command,
+		"Command Code: %s (0x%04X)", (message_def) ? message_def->name : "NotFoundInXML", command);
+	offset += 2;
+	proto_tree *sub_tree = proto_item_add_subtree(sub_item, ett_jaus_data);
+
+	if (message_def)
+	{
+		offset = dissect_message_data(tvb, sub_tree, offset, message_def);
+	}
+	return offset;
+}
+
+/**
+ * Returns the number of bytes based of the data type.
+ *
+ */
+int get_number_of_bytes(char type)
+{
+	if (type == PDT_BAD) {
+		return(-1); /* Bad Primitive Data Type, error with xml likely */
+	}
+
+	if (type == PDT_BYTE || type == PDT_UBYTE)
+		return(1);
+	else if (type == PDT_SHORT_INT || type == PDT_USHORT_INT)
+		return(2);
+	else if (type == PDT_INT || type == PDT_UINT || type == PDT_FLOAT)
+		return(4);
+	else /* if (type == PDT_LONG_INT || type == PDT_ULONG_INT || type == PDT_LONG_FLOAT) */
+		return(8);
+}
+
+/**
+ * Returns data from the buffer of size based of the type.
+ *  always of type guint64, cast as needed.
+ */
+int get_data_from_tvb(tvbuff_t *tvb, int offset, char type, int size, guint64 *data)
+{
+	if (type == PDT_BAD) {
+		return(-1); /* Bad Primitive Data Type, error with xml likely */
+	}
+
+	if (tvb_length_remaining(tvb, offset) < size) {
+		return(-2); /* malformed packet likely */
+	}
+
+	if (type == PDT_BYTE || type == PDT_UBYTE)
+		*data = (guint64)tvb_get_guint8(tvb, offset);
+	else if (type == PDT_SHORT_INT || type == PDT_USHORT_INT)
+		*data = (guint64)tvb_get_letohs(tvb, offset);/* Little-Endian-to-host-order accessors */
+	else if (type == PDT_INT || type == PDT_UINT || type == PDT_FLOAT)
+		*data = (guint64)tvb_get_letohl(tvb, offset);
+	else /* if (type == PDT_LONG_INT || type == PDT_ULONG_INT || type == PDT_LONG_FLOAT) */
+		*data = tvb_get_letoh64(tvb, offset);
+
+	return(0);
+}
+
+/**
+ * Used to convert a scaled int value to real double value for scale_range.
+ *
+ *  Returns real_value depending on int_function (floor, ceil, round).
+ */
+double scale_convert(unsigned int scaled_value, int bits, double real_lower, double real_upper, char int_function)
+{
+    double integer_range = pow(2,bits) - 1;
+    double scale_factor = (real_upper - real_lower) / integer_range;
+    double bias = real_lower;
+    double real_value = scaled_value * scale_factor + bias;
+
+	if (int_function == ROUND)
+		return(real_value);
+	else if (int_function == FLOOR)
+		return(floor(real_value));
+	else return(ceil(real_value));
+}
+
+/**
+ * Formats SDP JAUS ID as string for display.
+ *
+ *  Returns output of sprintf.
+ */
+int get_sdp_id_from_tvb(tvbuff_t *tvb, int offset, char* jaus_id)
+{
+	const int comp = tvb_get_guint8(tvb , offset);
+	const int node = tvb_get_guint8(tvb , offset+1);
+	const int subs = tvb_get_letohs(tvb , offset+2);
+	return sprintf(jaus_id, "%d.%d.%d", subs, node, comp);
+}
+
+/**
+ * Formats RA3 JAUS ID as string for display.
+ *
+ *  Returns output of sprintf.
+ */
+int get_ra3_id_from_tvb(tvbuff_t *tvb, int offset, char* jaus_id)
+{
+	const int inst = tvb_get_guint8(tvb , offset);
+	const int comp = tvb_get_guint8(tvb , offset+1);
+	const int node = tvb_get_guint8(tvb , offset+2);
+	const int subs = tvb_get_guint8(tvb , offset+3);
+	return sprintf(jaus_id, "%d.%d.%d.%d", subs, node, comp, inst);
+}
+
+char *decode_field_type(char type)
+{
+	static char result[32];
+	switch (type)
+	{
+	case PDT_BYTE:
+		return "byte";
+	case PDT_SHORT_INT:
+		return "short integer";
+	case PDT_INT:
+		return "integer";
+	case PDT_LONG_INT:
+		return "long integer";
+	case PDT_UBYTE:
+		return "unsigned byte";
+	case PDT_USHORT_INT:
+		return "unsigned short integer";
+	case PDT_UINT:
+		return "unsigned integer";
+	case PDT_ULONG_INT:
+		return "unsigned long integer";
+	case PDT_FLOAT:
+		return "float";
+	case PDT_LONG_FLOAT:
+		return "long float";
+	default:
+		sprintf(result, "UNKNOWN(%d)", (int)type);
+		return result;
+	}
+}
+
+message_def_t *get_message_def(guint16 command)
+{
+	message_def_t *message_ptr = message_set;
+	while (message_ptr != NULL)
+	{
+		if (message_ptr->message_id == command)
+		{
+			break;
+		}
+		message_ptr = message_ptr->next;
+	}
+	return message_ptr;
+}


### PR DESCRIPTION
Tested on Ubuntu 22.04 and 24.04 with Wireshark 4.6.6. Note, to get 4.6.6 on 22.04 and 24.04 I needed to `add-apt-repository ppa:wireshark-dev/stable`. Then update, and upgrade.

Also tested on 26.04 with Wireshark 4.6.4 which ships stock.

The changes were mostly related to the build system helpers for generating the code, with only a few code updates.

There are two code changes that aren't backwards compatible:

- `tvb_get_guint8` is deprecated, changed to `tvb_get_uint8` to avoid compiler warnings.
- `val_to_str` now needs a memory pool for generating the string. This is achieved by passing the first argument of `pinfo->pool` to the function.

Aside from these two changes, the rest appear to backwards compatible, but I'm not sure about the long term plan to support older versions. [According to Wireshark](https://wiki.wireshark.org/Development/LifeCycle), the only supported versions are 4.4 and 4.6. I'll leave it up to the maintainers to decide what effort should be made to back port.

Wireshark 4 and newer does introduce a number of helpful graphing features and is worth the jump for those that have not yet made it.